### PR TITLE
Change used BuildStepMonitor to NONE so allure reports can be published

### DIFF
--- a/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisher.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisher.java
@@ -124,7 +124,7 @@ public class AllureReportPublisher extends Recorder implements Serializable, Mat
 
     @Override
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.STEP;
+        return BuildStepMonitor.NONE;
     }
 
     @Override


### PR DESCRIPTION
So the publish report step does not get stuck. This bothers me a lot, and reports are actually independent -- why did we have the STEP in the first place?
