### PR TITLE
Add config YML param to plugin for ability to set config per job

### DIFF
--- a/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisher.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisher.java
@@ -66,6 +66,8 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
 
     private AllureReportConfig config;
 
+    private String configYml;
+
     private String jdk;
 
     private String commandline;
@@ -106,6 +108,11 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
     @DataBoundSetter
     public void setConfig(final AllureReportConfig config) {
         this.config = config;
+    }
+
+    @DataBoundSetter
+    public void setConfigYml(final String configYml) {
+        this.configYml = configYml;
     }
 
     @DataBoundSetter
@@ -175,6 +182,10 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
 
     public String getReport() {
         return this.report == null ? "allure-report" : this.report;
+    }
+
+    public String getConfigYml() {
+        return configYml;
     }
 
     @Nonnull
@@ -288,10 +299,18 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
         setAllureProperties(buildEnvVars);
         configureJdk(launcher, listener, buildEnvVars);
         final AllureCommandlineInstallation commandline = getCommandline(launcher, listener, buildEnvVars);
+
         final FilePath reportPath = workspace.child(getReport());
+        FilePath configYml = null;
+
+        try {
+            configYml = workspace.child(getConfigYml());
+        } catch (NullPointerException e) {
+            configYml = null;
+        }
 
         final int exitCode = new ReportBuilder(launcher, listener, workspace, buildEnvVars, commandline)
-                .build(resultsPaths, reportPath);
+                .build(resultsPaths, reportPath, configYml);
         if (exitCode != 0) {
             throw new AllurePluginException("Can not generate Allure Report, exit code: " + exitCode);
         }

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisher.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisher.java
@@ -66,7 +66,7 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
 
     private AllureReportConfig config;
 
-    private String configYml;
+    private String configPath;
 
     private String jdk;
 
@@ -111,8 +111,8 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
     }
 
     @DataBoundSetter
-    public void setConfigYml(final String configYml) {
-        this.configYml = configYml;
+    public void setConfigPath(final String configPath) {
+        this.configPath = configPath;
     }
 
     @DataBoundSetter
@@ -184,8 +184,8 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
         return this.report == null ? "allure-report" : this.report;
     }
 
-    public String getConfigYml() {
-        return configYml;
+    public String getConfigPath() {
+        return configPath;
     }
 
     @Nonnull
@@ -301,16 +301,16 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
         final AllureCommandlineInstallation commandline = getCommandline(launcher, listener, buildEnvVars);
 
         final FilePath reportPath = workspace.child(getReport());
-        FilePath configYml = null;
+        FilePath configPath = null;
 
         try {
-            configYml = workspace.child(getConfigYml());
+            configPath = workspace.child(getConfigPath());
         } catch (NullPointerException e) {
-            configYml = null;
+            configPath = null;
         }
 
         final int exitCode = new ReportBuilder(launcher, listener, workspace, buildEnvVars, commandline)
-                .build(resultsPaths, reportPath, configYml);
+                .build(resultsPaths, reportPath, configPath);
         if (exitCode != 0) {
             throw new AllurePluginException("Can not generate Allure Report, exit code: " + exitCode);
         }

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/ReportBuilder.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/ReportBuilder.java
@@ -39,14 +39,13 @@ public class ReportBuilder {
         this.listener = listener;
         this.envVars = envVars;
         this.commandline = commandline;
-
-        listener.getLogger().println("Starting allure report generate");
     }
 
-    public int build(@Nonnull List<FilePath> resultsPaths, @Nonnull FilePath reportPath, FilePath configYml) //NOSONAR
+    public int build(@Nonnull List<FilePath> resultsPaths, @Nonnull FilePath reportPath,
+                     FilePath configPath) //NOSONAR
             throws IOException, InterruptedException {
         final String version = commandline.getMajorVersion(launcher);
-        final ArgumentListBuilder arguments = getArguments(version, resultsPaths, reportPath, configYml);
+        final ArgumentListBuilder arguments = getArguments(version, resultsPaths, reportPath, configPath);
 
 
 
@@ -55,14 +54,15 @@ public class ReportBuilder {
     }
 
     private ArgumentListBuilder getArguments(String version, @Nonnull List<FilePath> resultsPaths,
-                                             @Nonnull FilePath reportPath, FilePath configYml)
+                                             @Nonnull FilePath reportPath, FilePath configPath)
             throws IOException, InterruptedException {
-        return version.startsWith("2") ? getAllure2Arguments(resultsPaths, reportPath, configYml)
+        return version.startsWith("2") ? getAllure2Arguments(resultsPaths, reportPath, configPath)
                 : getAllure1Arguments(resultsPaths, reportPath);
     }
 
     private ArgumentListBuilder getAllure2Arguments(@Nonnull List<FilePath> resultsPaths,
-                                                    @Nonnull FilePath reportPath, FilePath configYml) //NOSONAR
+                                                    @Nonnull FilePath reportPath,
+                                                    FilePath configPath) //NOSONAR
             throws IOException, InterruptedException {
         final ArgumentListBuilder arguments = new ArgumentListBuilder();
         arguments.add(commandline.getExecutable(launcher));
@@ -73,9 +73,9 @@ public class ReportBuilder {
         arguments.add(CLEAN_OPTION);
         arguments.add(OUTPUT_DIR_OPTION);
         arguments.add(reportPath.getRemote());
-        if (configYml != null) {
+        if (configPath != null) {
             arguments.add(CONFIG_OPTION);
-            arguments.add(configYml.getRemote());
+            arguments.add(configPath.getRemote());
         }
         return arguments;
     }

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/ReportBuilder.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/ReportBuilder.java
@@ -20,6 +20,8 @@ public class ReportBuilder {
     private static final String GENERATE_COMMAND = "generate";
     private static final String OUTPUT_DIR_OPTION = "-o";
     private static final String CLEAN_OPTION = "-c";
+    private static final String CONFIG_OPTION = "--config";
+
     private final FilePath workspace;
 
     private final Launcher launcher;
@@ -37,26 +39,30 @@ public class ReportBuilder {
         this.listener = listener;
         this.envVars = envVars;
         this.commandline = commandline;
+
+        listener.getLogger().println("Starting allure report generate");
     }
 
-    public int build(@Nonnull List<FilePath> resultsPaths, @Nonnull FilePath reportPath) //NOSONAR
+    public int build(@Nonnull List<FilePath> resultsPaths, @Nonnull FilePath reportPath, FilePath configYml) //NOSONAR
             throws IOException, InterruptedException {
         final String version = commandline.getMajorVersion(launcher);
-        final ArgumentListBuilder arguments = getArguments(version, resultsPaths, reportPath);
+        final ArgumentListBuilder arguments = getArguments(version, resultsPaths, reportPath, configYml);
+
+
 
         return launcher.launch().cmds(arguments)
                 .envs(envVars).stdout(listener).pwd(workspace).join();
     }
 
     private ArgumentListBuilder getArguments(String version, @Nonnull List<FilePath> resultsPaths,
-                                             @Nonnull FilePath reportPath)
+                                             @Nonnull FilePath reportPath, FilePath configYml)
             throws IOException, InterruptedException {
-        return version.startsWith("2") ? getAllure2Arguments(resultsPaths, reportPath)
+        return version.startsWith("2") ? getAllure2Arguments(resultsPaths, reportPath, configYml)
                 : getAllure1Arguments(resultsPaths, reportPath);
     }
 
     private ArgumentListBuilder getAllure2Arguments(@Nonnull List<FilePath> resultsPaths,
-                                                    @Nonnull FilePath reportPath) //NOSONAR
+                                                    @Nonnull FilePath reportPath, FilePath configYml) //NOSONAR
             throws IOException, InterruptedException {
         final ArgumentListBuilder arguments = new ArgumentListBuilder();
         arguments.add(commandline.getExecutable(launcher));
@@ -67,6 +73,10 @@ public class ReportBuilder {
         arguments.add(CLEAN_OPTION);
         arguments.add(OUTPUT_DIR_OPTION);
         arguments.add(reportPath.getRemote());
+        if (configYml != null) {
+            arguments.add(CONFIG_OPTION);
+            arguments.add(configYml.getRemote());
+        }
         return arguments;
     }
 

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/config/AllureReportConfig.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/config/AllureReportConfig.java
@@ -121,7 +121,6 @@ public class AllureReportConfig implements Serializable {
     }
 
     private static List<ResultsConfig> convertPaths(String paths) {
-
         return convertPaths(Arrays.asList(paths.split("\\n")));
     }
 

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/config/AllureReportConfig.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/config/AllureReportConfig.java
@@ -35,6 +35,8 @@ public class AllureReportConfig implements Serializable {
 
     private Boolean includeProperties = Boolean.TRUE;
 
+    private String configPath = "";
+
     @DataBoundConstructor
     public AllureReportConfig(List<ResultsConfig> results) {
         this.results = results == null ? Collections.<ResultsConfig>emptyList() : results;
@@ -91,29 +93,35 @@ public class AllureReportConfig implements Serializable {
         this.includeProperties = includeProperties;
     }
 
+    @DataBoundSetter
+    public void setConfigPath(String configPath) {
+        this.configPath = configPath;
+    }
+
     public boolean getIncludeProperties() {
         return includeProperties;
     }
 
     public static AllureReportConfig newInstance(List<String> results) {
-
-        return newInstance(null, null, results.toArray(new String[]{}));
+        return newInstance(null, null, null, results.toArray(new String[]{}));
     }
 
-    public static AllureReportConfig newInstance(String jdk, String commandline, String... paths) {
-        return newInstance(jdk, commandline, Arrays.asList(paths));
+    public static AllureReportConfig newInstance(String jdk, String commandline, String configPath, String... paths) {
+        return newInstance(jdk, commandline, configPath, Arrays.asList(paths));
     }
 
-    private static AllureReportConfig newInstance(String jdk, String commandline, List<String> paths) {
+    private static AllureReportConfig newInstance(String jdk, String commandline, String configPath, List<String> paths) {
         final List<ResultsConfig> results = convertPaths(paths);
         final AllureReportConfig config = new AllureReportConfig(results);
         config.setJdk(jdk);
         config.setCommandline(commandline);
         config.setIncludeProperties(true);
+        config.setConfigPath(configPath);
         return config;
     }
 
     private static List<ResultsConfig> convertPaths(String paths) {
+
         return convertPaths(Arrays.asList(paths.split("\\n")));
     }
 

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/dsl/AllureReportPublisherContext.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/dsl/AllureReportPublisherContext.java
@@ -48,7 +48,7 @@ class AllureReportPublisherContext implements Context {
         getPublisher().setIncludeProperties(includeProperties);
     }
 
-    public void configYml(String configYml) {
-        getPublisher().setConfigYml(configYml);
+    public void configPath(String configPath) {
+        getPublisher().setConfigPath(configPath);
     }
 }

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/dsl/AllureReportPublisherContext.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/dsl/AllureReportPublisherContext.java
@@ -47,4 +47,8 @@ class AllureReportPublisherContext implements Context {
     public void includeProperties(boolean includeProperties) {
         getPublisher().setIncludeProperties(includeProperties);
     }
+
+    public void configYml(String configYml) {
+        getPublisher().setConfigYml(configYml);
+    }
 }

--- a/src/main/resources/ru/yandex/qatools/allure/jenkins/AllureReportPublisher/config.jelly
+++ b/src/main/resources/ru/yandex/qatools/allure/jenkins/AllureReportPublisher/config.jelly
@@ -84,8 +84,8 @@
             <f:textbox value="${instance.getReport()}" default="allure-report" clazz="required"
                        checkMessage="Path can't be empty!"/>
         </f:entry>
-        <f:entry title="${%Config}:" field="configYml" description="${%ConfigDescription}">
-            <f:textbox value="${instance.getConfigYml()}" default=""/>
+        <f:entry title="${%Config}:" field="configPath" description="${%ConfigDescription}">
+            <f:textbox value="${instance.getConfigPath()}" default=""/>
         </f:entry>
     </f:advanced>
 </j:jelly>

--- a/src/main/resources/ru/yandex/qatools/allure/jenkins/AllureReportPublisher/config.jelly
+++ b/src/main/resources/ru/yandex/qatools/allure/jenkins/AllureReportPublisher/config.jelly
@@ -2,85 +2,90 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
-        <f:entry title="${%Disabled}" field="disabled">
-            <f:checkbox checked="${instance.isDisabled()}"/>
-        </f:entry>
-        <f:entry title="${%Results}:" field="results" description="${%ResultsDescription}">
-            <f:repeatable var="results" items="${instance.getResults()}" minimum="1">
-                <table width="90%">
-                    <f:entry title="Path" field="path">
-                        <f:textbox value="${results.path}" default="allure-results" clazz="required"
-                                   checkMessage="Path can't be empty!"/>
-                    </f:entry>
-                </table>
-                <div align="right">
-                    <f:repeatableDeleteButton/>
-                </div>
-            </f:repeatable>
-        </f:entry>
-        <f:entry title="${%Properties}" field="properties">
-            <f:repeatable var="properties" items="${instance.getProperties()}">
-                <table width="100%">
-                    <f:entry title="Key" field="key">
-                        <f:textbox width="50%" value="${properties.key}" clazz="required"
-                                   checkMessage="Property key can't be empty!" autoCompleteField="propertyKey"/>
-                    </f:entry>
-                    <f:entry title="Value" field="value">
-                        <f:textbox width="50%" value="${properties.value}"/>
-                    </f:entry>
-                </table>
-                <div align="right">
-                    <f:repeatableDeleteButton/>
-                </div>
-            </f:repeatable>
-        </f:entry>
-        <j:set var="installations" value="${descriptor.getCommandlineInstallations()}"/>
-        <f:entry>
-            <j:if test="${empty(installations)}">
-                <div class="error">
-                    ${%CommandlineMissingError(rootURL)}
-                </div>
-            </j:if>
-        </f:entry>
-        <f:advanced>
-            <j:if test="${installations.size() > 1}">
-                <f:entry title="${%Commandline}:">
-                    <select class="setting-input" style="width: 90%" name="commandline">
-                        <j:forEach var="inst" items="${installations}">
-                            <f:option selected="${inst.name==instance.getCommandline()}"
-                                      value="${inst.name}">
-                                ${inst.name}
-                            </f:option>
-                        </j:forEach>
-                    </select>
+    <f:entry title="${%Disabled}" field="disabled">
+        <f:checkbox checked="${instance.isDisabled()}"/>
+    </f:entry>
+    <f:entry title="${%Results}:" field="results" description="${%ResultsDescription}">
+        <f:repeatable var="results" items="${instance.getResults()}" minimum="1">
+            <table width="90%">
+                <f:entry title="Path" field="path">
+                    <f:textbox value="${results.path}" default="allure-results" clazz="required"
+                               checkMessage="Path can't be empty!"/>
                 </f:entry>
-            </j:if>
-            <j:set var="jdks" value="${app.JDKs}"/>
-            <f:entry title="JDK" description="${%JDKDescription}">
-                <select class="setting-input" style="width: 90%" name="jdk">
-                    <option value="">${%InheritFromJob}</option>
-                    <j:forEach var="inst" items="${jdks}">
-                        <f:option selected="${inst.name==instance.getJdk()}" value="${inst.name}">
+            </table>
+            <div align="right">
+                <f:repeatableDeleteButton/>
+            </div>
+        </f:repeatable>
+    </f:entry>
+    <f:entry title="${%Properties}" field="properties">
+        <f:repeatable var="properties" items="${instance.getProperties()}">
+            <table width="100%">
+                <f:entry title="Key" field="key">
+                    <f:textbox width="50%" value="${properties.key}" clazz="required"
+                               checkMessage="Property key can't be empty!"
+                               autoCompleteField="propertyKey"/>
+                </f:entry>
+                <f:entry title="Value" field="value">
+                    <f:textbox width="50%" value="${properties.value}"/>
+                </f:entry>
+            </table>
+            <div align="right">
+                <f:repeatableDeleteButton/>
+            </div>
+        </f:repeatable>
+    </f:entry>
+    <j:set var="installations" value="${descriptor.getCommandlineInstallations()}"/>
+    <f:entry>
+        <j:if test="${empty(installations)}">
+            <div class="error">
+                ${%CommandlineMissingError(rootURL)}
+            </div>
+        </j:if>
+    </f:entry>
+    <f:advanced>
+        <j:if test="${installations.size() > 1}">
+            <f:entry title="${%Commandline}:">
+                <select class="setting-input" style="width: 90%" name="commandline">
+                    <j:forEach var="inst" items="${installations}">
+                        <f:option selected="${inst.name==instance.getCommandline()}"
+                                  value="${inst.name}">
                             ${inst.name}
                         </f:option>
                     </j:forEach>
                 </select>
             </f:entry>
-            <f:entry title="${%Generate}:">
-                <j:forEach var='reportBuildPolicy' items='${descriptor.getReportBuildPolicies()}' varStatus="status">
-                    <f:radio title="${reportBuildPolicy.getTitle()}" name="reportBuildPolicy"
-                             value="${reportBuildPolicy.getValue()}"
-                             checked="${instance.getReportBuildPolicy() == null and status.first or
-                                instance.getReportBuildPolicy().equals(reportBuildPolicy)}"/>
-                    <br/>
+        </j:if>
+        <j:set var="jdks" value="${app.JDKs}"/>
+        <f:entry title="JDK" description="${%JDKDescription}">
+            <select class="setting-input" style="width: 90%" name="jdk">
+                <option value="">${%InheritFromJob}</option>
+                <j:forEach var="inst" items="${jdks}">
+                    <f:option selected="${inst.name==instance.getJdk()}" value="${inst.name}">
+                        ${inst.name}
+                    </f:option>
                 </j:forEach>
-            </f:entry>
-            <f:entry title="${%IncludeEnvironment}" field="includeProperties">
-                <f:checkbox checked="${instance.getIncludeProperties()}"/>
-            </f:entry>
-            <f:entry title="${%Report}:" field="report" description="${%ReportDescription}">
-                <f:textbox value="${instance.getReport()}" default="allure-report" clazz="required"
-                           checkMessage="Path can't be empty!"/>
-            </f:entry>
-        </f:advanced>
+            </select>
+        </f:entry>
+        <f:entry title="${%Generate}:">
+            <j:forEach var='reportBuildPolicy' items='${descriptor.getReportBuildPolicies()}'
+                       varStatus="status">
+                <f:radio title="${reportBuildPolicy.getTitle()}" name="reportBuildPolicy"
+                         value="${reportBuildPolicy.getValue()}"
+                         checked="${instance.getReportBuildPolicy() == null and status.first or
+                                instance.getReportBuildPolicy().equals(reportBuildPolicy)}"/>
+                <br/>
+            </j:forEach>
+        </f:entry>
+        <f:entry title="${%IncludeEnvironment}" field="includeProperties">
+            <f:checkbox checked="${instance.getIncludeProperties()}"/>
+        </f:entry>
+        <f:entry title="${%Report}:" field="report" description="${%ReportDescription}">
+            <f:textbox value="${instance.getReport()}" default="allure-report" clazz="required"
+                       checkMessage="Path can't be empty!"/>
+        </f:entry>
+        <f:entry title="${%Config}:" field="configYml" description="${%ConfigDescription}">
+            <f:textbox value="${instance.getConfigYml()}" default=""/>
+        </f:entry>
+    </f:advanced>
 </j:jelly>

--- a/src/main/resources/ru/yandex/qatools/allure/jenkins/AllureReportPublisher/config.properties
+++ b/src/main/resources/ru/yandex/qatools/allure/jenkins/AllureReportPublisher/config.properties
@@ -1,4 +1,4 @@
-Disabled = Disabled
+Disabled=Disabled
 Results=Results
 ResultsDescription=Paths to Allure results directories relative from workspace.<br/>E.g. <strong>target/allure-results</strong>.
 Commandline=Commandline
@@ -6,5 +6,7 @@ IncludeEnvironment=Include build environment
 CommandlineMissingError=Jenkins needs to know where your 'Allure Commandline' is installed.<br/>\
    Please do so from the <a href="{0}/configureTools" target="_new">Global Tool Configuration</a>.
 JDKDescription=JDK to be used for the report building. <strong>jdk8 or above</strong>.
-Report = Report path
-ReportDescription = Paths to Allure report directory relative from workspace.<br/>E.g. <strong>allure-report</strong>.
+Report=Report path
+ReportDescription=Paths to Allure report directory relative from workspace.<br/>E.g. <strong>allure-report</strong>.
+Config=Allure Configuration (config.yml)
+ConfigDescription=Path to config.yml which should be used to generate report

--- a/src/test/java/ru/yandex/qatools/allure/jenkins/CommandlineIT.java
+++ b/src/test/java/ru/yandex/qatools/allure/jenkins/CommandlineIT.java
@@ -52,7 +52,7 @@ public class CommandlineIT {
             results.child("sample-testsuite.xml").copyFrom(is);
         }
         FilePath report = new FilePath(folder.getRoot()).child("some folder with (x22) spaces");
-        int exitCode = builder.build(Collections.singletonList(results), report);
+        int exitCode = builder.build(Collections.singletonList(results), report, null);
         assertThat(exitCode).as("Should exit with code 0").isEqualTo(0);
     }
 }

--- a/src/test/java/ru/yandex/qatools/allure/jenkins/JobDslIT.java
+++ b/src/test/java/ru/yandex/qatools/allure/jenkins/JobDslIT.java
@@ -53,6 +53,8 @@ public class JobDslIT {
                 .containsExactly(new PropertyConfig("key", "value"));
 
         assertThat(allureReportPublisher.getIncludeProperties()).isEqualTo(Boolean.TRUE);
+
+        assertThat(allureReportPublisher.getConfigYml()).isEqualTo(null);
     }
 
     private FreeStyleProject buildJob(String script) throws Exception {

--- a/src/test/java/ru/yandex/qatools/allure/jenkins/JobDslIT.java
+++ b/src/test/java/ru/yandex/qatools/allure/jenkins/JobDslIT.java
@@ -54,7 +54,7 @@ public class JobDslIT {
 
         assertThat(allureReportPublisher.getIncludeProperties()).isEqualTo(Boolean.TRUE);
 
-        assertThat(allureReportPublisher.getConfigYml()).isEqualTo(null);
+        assertThat(allureReportPublisher.getConfigPath()).isEqualTo(null);
     }
 
     private FreeStyleProject buildJob(String script) throws Exception {


### PR DESCRIPTION
PR will add the ability to set (optionally) a config path for Allure.

This is helpful in turning on and off plugins in Allure when using the Jenkins plugin.