### PR TITLE
Treat "failure" builds as unsuccessful in ReportBuildPolicy

### DIFF
--- a/src/main/java/ru/yandex/qatools/allure/jenkins/config/ReportBuildPolicy.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/config/ReportBuildPolicy.java
@@ -27,7 +27,11 @@ public enum ReportBuildPolicy {
     UNSUCCESSFUL("For unsuccessful builds", new ReportBuildPolicyDecision() {
         @Override
         public boolean isNeedToBuildReport(Run run) {
-            return run != null && Result.UNSTABLE.equals(run.getResult());
+            return run != null && isUnsuccessful(run.getResult());
+        }
+
+        private boolean isUnsuccessful(Result result) {
+            return Result.UNSTABLE.equals(result) || Result.FAILURE.equals(result);
         }
     });
 


### PR DESCRIPTION
`UNSUCCESSFUL` ReportBuildPolicy currently is the same as `UNSTABLE` and works only for unstable builds, but it should work for failed builds also. The PR fixes that.