### PR TITLE
Fix crash on broken history

### DIFF
--- a/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisher.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisher.java
@@ -416,12 +416,12 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
     private void addHistory(@Nonnull List<FilePath> resultsPaths, @Nonnull Run<?, ?> run,
                             @Nonnull FilePath workspace, @Nonnull TaskListener listener)
             throws IOException, InterruptedException {
-        final String reportPath = workspace.child(getReport()).getName();
-        final FilePath previousReport = FilePathUtils.getPreviousReportWithHistory(run, reportPath);
-        if (previousReport == null) {
-            return;
-        }
         try {
+            final String reportPath = workspace.child(getReport()).getName();
+            final FilePath previousReport = FilePathUtils.getPreviousReportWithHistory(run, reportPath);
+            if (previousReport == null) {
+                return;
+            }
             copyHistoryToResultsPaths(resultsPaths, previousReport, workspace);
         } catch (Exception e) {
             listener.getLogger().println("Cannot find a history information about previous builds.");


### PR DESCRIPTION
Allure plugin may crash if history is broken:

```
[Pipeline] allure
Error when executing always post condition:
java.util.zip.ZipException: error in opening zip file
	at java.util.zip.ZipFile.open(Native Method)
	at java.util.zip.ZipFile.<init>(ZipFile.java:225)
	at java.util.zip.ZipFile.<init>(ZipFile.java:155)
	at java.util.zip.ZipFile.<init>(ZipFile.java:126)
	at ru.yandex.qatools.allure.jenkins.utils.FilePathUtils.isHistoryNotEmpty(FilePathUtils.java:79)
	at ru.yandex.qatools.allure.jenkins.utils.FilePathUtils.getPreviousReportWithHistory(FilePathUtils.java:70)
	at ru.yandex.qatools.allure.jenkins.AllureReportPublisher.addHistory(AllureReportPublisher.java:402)
	at ru.yandex.qatools.allure.jenkins.AllureReportPublisher.prepareResults(AllureReportPublisher.java:371)
	at ru.yandex.qatools.allure.jenkins.AllureReportPublisher.perform(AllureReportPublisher.java:217)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:80)
	at org.jenkinsci.plugins.workflow.steps.CoreStep$Execution.run(CoreStep.java:67)
	at org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution.lambda$start$0(SynchronousNonBlockingStepExecution.java:47)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```