### PR TITLE
Update jackson-databind, bcprov-jdk15on, commons-compress

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,9 @@ dependencies {
     compile 'org.jenkins-ci:symbol-annotation:1.5'
     compile 'de.schlichtherle.truezip:truezip-file:7.7.10'
     compile 'de.schlichtherle.truezip:truezip-driver-zip:7.7.10'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.7.0'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.13.1'
+    compile 'org.bouncycastle:bcprov-jdk15on:1.70'
+    compile 'org.apache.commons:commons-compress:1.21'
 
     jenkinsPlugins 'org.jenkins-ci.plugins:script-security:1.25@jar'
     jenkinsPlugins 'org.jenkins-ci.plugins:matrix-project:1.11@jar'

--- a/src/test/java/ru/yandex/qatools/allure/jenkins/callables/AddTestRunInfoTest.java
+++ b/src/test/java/ru/yandex/qatools/allure/jenkins/callables/AddTestRunInfoTest.java
@@ -22,7 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 public class AddTestRunInfoTest {
 
-    private static final TypeReference TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {
+    private static final TypeReference<Map<String, Object>> TYPE_REFERENCE = new TypeReference<Map<String, Object>>() {
     };
 
     @Rule


### PR DESCRIPTION
Update com.fasterxml.jackson.core:jackson-databind from 2.7.0 to 2.13.1
fixing security vulnerabilities:
https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind/2.7.0

Update org.bouncycastle:bcprov-jdk15on from 1.52 to 1.70
fixing security vulnerabilities:
https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on/1.52

Update org.apache.commons:commons-compress from 1.9 to 1.21
fixing security vulnerabilities:
https://mvnrepository.com/artifact/org.apache.commons/commons-compress/1.9

I haven't checked whether allure-jenkins-plugin is affected; however,
the update will at least fix false positive reports from various
security vulnerability scanners.

Fixes #287.

<!-- Please describe your pull request here. -->
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

I don't provide tests because it is not my task to create exploits for all vulnerabilities. Please consult the repositories of the dependencies to validate whether their fix actually fixes the vulnerability and whether they have added a test for each vulnerability.