### PR TITLE
feature: toggle for disable/enable update build result

### DIFF
--- a/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisher.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisher.java
@@ -86,6 +86,8 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
 
     private String report;
 
+    private Boolean updateBuildResult;
+
     @DataBoundConstructor
     public AllureReportPublisher(@Nonnull List<ResultsConfig> results) {
         this.results = results;
@@ -188,6 +190,15 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
 
     public String getConfigPath() {
         return StringUtils.isNotBlank(configPath) ? configPath : null;
+    }
+
+    public Boolean getUpdateBuildResult() {
+        return this.updateBuildResult == null ? Boolean.TRUE : this.updateBuildResult;
+    }
+
+    @DataBoundSetter
+    public void setUpdateBuildResult(Boolean updateBuildResult) {
+        this.updateBuildResult = updateBuildResult;
     }
 
     @Nonnull
@@ -318,7 +329,9 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
         AllureReportBuildAction buildAction = new AllureReportBuildAction(FilePathUtils.extractSummary(run, reportPath.getName()));
         buildAction.setReportPath(reportPath);
         run.addAction(buildAction);
-        run.setResult(buildAction.getBuildSummary().getResult());
+        if (Boolean.TRUE.equals(getUpdateBuildResult())) {
+            run.setResult(buildAction.getBuildSummary().getResult());
+        }
     }
 
     private void saveAllureArtifact(final Run<?, ?> run, final FilePath workspace, final TaskListener listener)

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/dsl/AllureReportPublisherContext.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/dsl/AllureReportPublisherContext.java
@@ -51,4 +51,8 @@ class AllureReportPublisherContext implements Context {
     public void configPath(String configPath) {
         getPublisher().setConfigPath(configPath);
     }
+
+    public void updateBuildResult(boolean updateBuildResult) {
+        getPublisher().setUpdateBuildResult(updateBuildResult);
+    }
 }

--- a/src/test/java/ru/yandex/qatools/allure/jenkins/ReportGenerateIT.java
+++ b/src/test/java/ru/yandex/qatools/allure/jenkins/ReportGenerateIT.java
@@ -124,6 +124,18 @@ public class ReportGenerateIT {
     }
 
     @Test
+    public void shouldGenerateReportWithSuccessfulResult() throws Exception {
+        FreeStyleProject project = jRule.createFreeStyleProject();
+        project.setScm(getSimpleFileScm("sample-testsuite-with-failed.xml", ALLURE_RESULTS));
+        AllureReportPublisher publisher = createAllurePublisher(jdk, commandline, "allure-results");
+        publisher.setUpdateBuildResult(Boolean.FALSE);
+        project.getPublishersList().add(publisher);
+        FreeStyleBuild build = jRule.assertBuildStatus(Result.SUCCESS, project.scheduleBuild2(0));
+
+        assertThat(build.getActions(AllureReportBuildAction.class)).hasSize(1);
+    }
+
+    @Test
     public void shouldGenerateReportForGlob() throws Exception {
         FreeStyleProject project = jRule.createFreeStyleProject();
         project.setScm(getSimpleFileScm("sample-testsuite.xml", "target/".concat(ALLURE_RESULTS)));


### PR DESCRIPTION
Use `updateBuildResult` (default true) to disable/enable updating the build result on Jenkins based on test results

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
