### PR TITLE
Bugfix for #215

### DIFF
--- a/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportBuildAction.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportBuildAction.java
@@ -208,11 +208,11 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
 
         for (AllureReportBuildAction a = this; a != null; a = a.getPreviousResult()) {
             final ChartUtil.NumberOnlyBuildLabel columnKey = new ChartUtil.NumberOnlyBuildLabel(a.run);
-            dsb.add(a.getFailedCount(), "failed", columnKey);
-            dsb.add(a.getBrokenCount(), "broken", columnKey);
-            dsb.add(a.getPassedCount(), "passed", columnKey);
-            dsb.add(a.getSkipCount(), "skipped", columnKey);
-            dsb.add(a.getUnknownCount(), "unknown", columnKey);
+            dsb.add(a.getFailedCount(), "a_failed", columnKey);
+            dsb.add(a.getBrokenCount(), "b_broken", columnKey);
+            dsb.add(a.getPassedCount(), "c_passed", columnKey);
+            dsb.add(a.getSkipCount(), "d_skipped", columnKey);
+            dsb.add(a.getUnknownCount(), "e_unknown", columnKey);
         }
         return dsb.build();
     }


### PR DESCRIPTION
Problem caused by DataSetBuilder.build(). The **rowKey** which is an instance of **TreeSet** is sorted by _natural ordering_.

The values of **rowKey** seems not visible to end users, got a quick way to fix the issue by adding a prefix to each of them.

[Issue#215](https://github.com/jenkinsci/allure-plugin/issues/215)

### Testing done

I have created a class to test this function. Just to save a .png picture to my local.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
