### PR TITLE
fix: Calling allure step multiple times in one build causes errors 

### DIFF
--- a/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisher.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisher.java
@@ -363,7 +363,9 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
         final AllureReportBuildAction buildAction = new AllureReportBuildAction(
                 FilePathUtils.extractSummary(run, reportPath.getName()));
         buildAction.setReportPath(reportPath);
-        run.addAction(buildAction);
+        // run.addAction(buildAction);
+        // change to below. Calling allure multiple times would produce many allure icons
+        run.addOrReplaceAction(buildAction);
         run.setResult(buildAction.getBuildSummary().getResult());
     }
 
@@ -383,7 +385,10 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
             Objects.requireNonNull(reportPath.getParent())
                     .archive(TrueZipArchiver.FACTORY, os, reportPath.getName() + "/**");
         }
-
+        if (archive.exists() && !archive.delete()) {
+            listener.getLogger().println("Artifact already exists but unable to be deleted");
+            return;
+        }
         Files.move(tempArchive.toPath(), archive.toPath());
         listener.getLogger().println("Artifact was added to the build.");
     }

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/utils/FilePathUtils.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/utils/FilePathUtils.java
@@ -83,7 +83,7 @@ public final class FilePathUtils {
     public static FilePath getPreviousReportWithHistory(final Run<?, ?> run,
                                                         final String reportPath)
             throws IOException, InterruptedException {
-        Run<?, ?> current = run;
+        Run<?, ?> current = run.getPreviousCompletedBuild();
         while (current != null) {
             final FilePath previousReport = new FilePath(current.getArtifactsDir()).child(ALLURE_REPORT_ZIP);
             if (previousReport.exists() && isHistoryNotEmpty(previousReport, reportPath)) {


### PR DESCRIPTION
The following errors has been fixed:
1. allure icon in the build history duplicated.
2. Files.move method error: allure-report.zip already exists.
