### PR TITLE
Add link to Allure Jenkins Integration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 * [Issues](https://github.com/jenkinsci/allure-plugin/issues?labels=&milestone=&page=1&state=open)
 * [Releases](https://github.com/jenkinsci/allure-plugin/releases)
+* [Documentation](https://allurereport.org/docs/integrations-jenkins/)
 
 ## Contact us
 * Mailing list: [allure@qameta.io](mailto:allure@qameta.io)


### PR DESCRIPTION
This repository doesn't have any links on how to work with this plugin, how to install it to Jenkins. Google search on _Allure Jenkins Plugin documentation_ doesn't point to it either. We can only find it someones issue - https://github.com/jenkinsci/allure-plugin/issues/318#issuecomment-1485384724

In this PR I added link to documentation to README file.
