### PR TITLE
Remove gitter from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ To learn more, please visit [the official documentation](https://allurereport.or
 * [Releases](https://github.com/jenkinsci/allure-plugin/releases)
 
 ## Contact us
+
 * Mailing list: [allure@qameta.io](mailto:allure@qameta.io)
-* Gitter chat room: [https://gitter.im/allure-framework/allure-core](https://gitter.im/allure-framework/allure-core)
 * StackOverflow tag: [Allure](http://stackoverflow.com/questions/tagged/allure)


### PR DESCRIPTION
The link to the Gitter chat room was removed from the README file.

### Testing done

No changes that require testing.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
