### PR TITLE
Replace JSR-305 annotations with spotbugs annotations

### DIFF
--- a/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisher.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisher.java
@@ -15,6 +15,7 @@
  */
 package ru.yandex.qatools.allure.jenkins;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -48,8 +49,7 @@ import ru.yandex.qatools.allure.jenkins.utils.BuildUtils;
 import ru.yandex.qatools.allure.jenkins.utils.FilePathUtils;
 import ru.yandex.qatools.allure.jenkins.utils.TrueZipArchiver;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -101,7 +101,7 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
     private String report;
 
     @DataBoundConstructor
-    public AllureReportPublisher(final @Nonnull List<ResultsConfig> results) {
+    public AllureReportPublisher(final @NonNull List<ResultsConfig> results) {
         this.results = results;
     }
 
@@ -156,9 +156,9 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
     }
 
     private AllureCommandlineInstallation getCommandline(
-            final @Nonnull Launcher launcher,
-            final @Nonnull TaskListener listener,
-            final @Nonnull EnvVars env)
+            final @NonNull Launcher launcher,
+            final @NonNull TaskListener listener,
+            final @NonNull EnvVars env)
             throws IOException, InterruptedException {
 
         // discover commandline
@@ -226,29 +226,29 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
         return StringUtils.isNotBlank(configPath) ? configPath : null;
     }
 
-    @Nonnull
+    @NonNull
     public AllureReportConfig getConfig() {
         return config;
     }
 
     @Override
-    @Nonnull
+    @NonNull
     public BuildStepMonitor getRequiredMonitorService() {
         return BuildStepMonitor.NONE;
     }
 
     @Override
-    @Nonnull
+    @NonNull
     public AllureReportPublisherDescriptor getDescriptor() {
         return (AllureReportPublisherDescriptor) super.getDescriptor();
     }
 
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     @Override
-    public void perform(final @Nonnull Run<?, ?> run,
-                        final @Nonnull FilePath workspace,
-                        final @Nonnull Launcher launcher,
-                        final @Nonnull TaskListener listener) throws InterruptedException, IOException {
+    public void perform(final @NonNull Run<?, ?> run,
+                        final @NonNull FilePath workspace,
+                        final @NonNull Launcher launcher,
+                        final @NonNull TaskListener listener) throws InterruptedException, IOException {
         if (isDisabled()) {
             listener.getLogger().println("Allure report is disabled.");
             return;
@@ -282,9 +282,9 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
      * between perform and createAggregator, because for concurrent builds (Jenkins provides such feature)
      * state objects will be corrupted.
      */
-    private void copyResultsToParentIfNeeded(final @Nonnull List<FilePath> results,
-                                             final @Nonnull Run<?, ?> run,
-                                             final @Nonnull TaskListener listener
+    private void copyResultsToParentIfNeeded(final @NonNull List<FilePath> results,
+                                             final @NonNull Run<?, ?> run,
+                                             final @NonNull TaskListener listener
     ) throws IOException, InterruptedException {
         if (run instanceof MatrixRun) {
             final MatrixBuild parentBuild = ((MatrixRun) run).getParentBuild();
@@ -328,11 +328,11 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
     }
 
     @SuppressWarnings("TrailingComment")
-    private void generateReport(final @Nonnull List<FilePath> resultsPaths,
-                                final @Nonnull Run<?, ?> run,
-                                final @Nonnull FilePath workspace,
-                                final @Nonnull Launcher launcher,
-                                final @Nonnull TaskListener listener
+    private void generateReport(final @NonNull List<FilePath> resultsPaths,
+                                final @NonNull Run<?, ?> run,
+                                final @NonNull FilePath workspace,
+                                final @NonNull Launcher launcher,
+                                final @NonNull TaskListener listener
     ) throws IOException, InterruptedException { //NOSONAR
 
         final ReportBuildPolicy reportBuildPolicy = getReportBuildPolicy();
@@ -406,7 +406,7 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
         envVars.put("ALLURE_OPTS", options.toString());
     }
 
-    @Nonnull
+    @NonNull
     @Override
     public Collection<? extends Action> getProjectActions(final AbstractProject<?, ?> project) {
         return Collections.singleton(new AllureReportProjectAction(
@@ -414,10 +414,10 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
         ));
     }
 
-    private void prepareResults(final @Nonnull List<FilePath> resultsPaths,
-                                final @Nonnull Run<?, ?> run,
-                                final @Nonnull FilePath workspace,
-                                final @Nonnull TaskListener listener)
+    private void prepareResults(final @NonNull List<FilePath> resultsPaths,
+                                final @NonNull Run<?, ?> run,
+                                final @NonNull FilePath workspace,
+                                final @NonNull TaskListener listener)
             throws IOException, InterruptedException {
         addHistory(resultsPaths, run, workspace, listener);
         addTestRunInfo(resultsPaths, run);
@@ -425,8 +425,8 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
     }
 
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
-    private void addTestRunInfo(final @Nonnull List<FilePath> resultsPaths,
-                                final @Nonnull Run<?, ?> run)
+    private void addTestRunInfo(final @NonNull List<FilePath> resultsPaths,
+                                final @NonNull Run<?, ?> run)
             throws IOException, InterruptedException {
         final long start = run.getStartTimeInMillis();
         final long stop = run.getTimeInMillis();
@@ -435,8 +435,8 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
         }
     }
 
-    private void addExecutorInfo(final @Nonnull List<FilePath> resultsPaths,
-                                 final @Nonnull Run<?, ?> run)
+    private void addExecutorInfo(final @NonNull List<FilePath> resultsPaths,
+                                 final @NonNull Run<?, ?> run)
             throws IOException, InterruptedException {
 
         final String rootUrl = Jenkins.get().getRootUrl();
@@ -450,10 +450,10 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
         }
     }
 
-    private void addHistory(final @Nonnull List<FilePath> resultsPaths,
-                            final @Nonnull Run<?, ?> run,
-                            final @Nonnull FilePath workspace,
-                            final @Nonnull TaskListener listener) {
+    private void addHistory(final @NonNull List<FilePath> resultsPaths,
+                            final @NonNull Run<?, ?> run,
+                            final @NonNull FilePath workspace,
+                            final @NonNull TaskListener listener) {
         try {
             final String reportPath = workspace.child(getReport()).getName();
             final FilePath previousReport = FilePathUtils.getPreviousReportWithHistory(run, reportPath);
@@ -467,9 +467,9 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
         }
     }
 
-    private void copyHistoryToResultsPaths(final @Nonnull List<FilePath> resultsPaths,
-                                           final @Nonnull FilePath previousReport,
-                                           final @Nonnull FilePath workspace)
+    private void copyHistoryToResultsPaths(final @NonNull List<FilePath> resultsPaths,
+                                           final @NonNull FilePath previousReport,
+                                           final @NonNull FilePath workspace)
             throws IOException, InterruptedException {
         try (ZipFile archive = new ZipFile(previousReport.getRemote())) {
             for (FilePath resultsPath : resultsPaths) {
@@ -479,8 +479,8 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
     }
 
     private void copyHistoryToResultsPath(final ZipFile archive,
-                                          final @Nonnull FilePath resultsPath,
-                                          final @Nonnull FilePath workspace)
+                                          final @NonNull FilePath resultsPath,
+                                          final @NonNull FilePath workspace)
             throws IOException, InterruptedException {
         final FilePath reportPath = workspace.child(getReport());
         for (final ZipEntry historyEntry : listEntries(archive, reportPath.getName() + "/history")) {

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisherDescriptor.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/AllureReportPublisherDescriptor.java
@@ -18,6 +18,7 @@ package ru.yandex.qatools.allure.jenkins;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.AutoCompletionCandidates;
@@ -33,7 +34,6 @@ import ru.yandex.qatools.allure.jenkins.config.PropertyConfig;
 import ru.yandex.qatools.allure.jenkins.config.ReportBuildPolicy;
 import ru.yandex.qatools.allure.jenkins.tools.AllureCommandlineInstallation;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,7 +69,7 @@ public class AllureReportPublisherDescriptor extends BuildStepDescriptor<Publish
     }
 
     @Override
-    @Nonnull
+    @NonNull
     public String getDisplayName() {
         return Messages.AllureReportPublisher_DisplayName();
     }
@@ -85,7 +85,7 @@ public class AllureReportPublisherDescriptor extends BuildStepDescriptor<Publish
     }
 
     @SuppressWarnings("unused")
-    @Nonnull
+    @NonNull
     public AutoCompletionCandidates doAutoCompletePropertyKey() {
         final AutoCompletionCandidates candidates = new AutoCompletionCandidates();
         candidates.add("allure.issues.tracker.pattern");
@@ -113,7 +113,7 @@ public class AllureReportPublisherDescriptor extends BuildStepDescriptor<Publish
         return true;
     }
 
-    @Nonnull
+    @NonNull
     public List<AllureCommandlineInstallation> getCommandlineInstallations() {
         return Optional.of(Jenkins.get())
                 .map(j -> j.getDescriptorByType(AllureCommandlineInstallation.DescriptorImpl.class))

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/ReportBuilder.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/ReportBuilder.java
@@ -15,6 +15,7 @@
  */
 package ru.yandex.qatools.allure.jenkins;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -22,7 +23,6 @@ import hudson.model.TaskListener;
 import hudson.util.ArgumentListBuilder;
 import ru.yandex.qatools.allure.jenkins.tools.AllureCommandlineInstallation;
 
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.List;
 
@@ -49,11 +49,11 @@ public class ReportBuilder {
 
     private FilePath configFilePath;
 
-    public ReportBuilder(final @Nonnull Launcher launcher,
-                         final @Nonnull TaskListener listener,
-                         final @Nonnull FilePath workspace,
-                         final @Nonnull EnvVars envVars,
-                         final @Nonnull AllureCommandlineInstallation commandline) {
+    public ReportBuilder(final @NonNull Launcher launcher,
+                         final @NonNull TaskListener listener,
+                         final @NonNull FilePath workspace,
+                         final @NonNull EnvVars envVars,
+                         final @NonNull AllureCommandlineInstallation commandline) {
         this.workspace = workspace;
         this.launcher = launcher;
         this.listener = listener;
@@ -65,8 +65,8 @@ public class ReportBuilder {
         this.configFilePath = configFilePath;
     }
 
-    public int build(final @Nonnull List<FilePath> resultsPaths,
-                     final @Nonnull FilePath reportPath) //NOSONAR
+    public int build(final @NonNull List<FilePath> resultsPaths,
+                     final @NonNull FilePath reportPath) //NOSONAR
             throws IOException, InterruptedException {
         final String version = commandline.getMajorVersion(launcher);
         final ArgumentListBuilder arguments = getArguments(version, resultsPaths, reportPath);
@@ -76,15 +76,15 @@ public class ReportBuilder {
     }
 
     private ArgumentListBuilder getArguments(final String version,
-                                             final @Nonnull List<FilePath> resultsPaths,
-                                             final @Nonnull FilePath reportPath)
+                                             final @NonNull List<FilePath> resultsPaths,
+                                             final @NonNull FilePath reportPath)
             throws IOException, InterruptedException {
         return version.startsWith("2") ? getAllure2Arguments(resultsPaths, reportPath)
                 : getAllure1Arguments(resultsPaths, reportPath);
     }
 
-    private ArgumentListBuilder getAllure2Arguments(final @Nonnull List<FilePath> resultsPaths,
-                                                    final @Nonnull FilePath reportPath) //NOSONAR
+    private ArgumentListBuilder getAllure2Arguments(final @NonNull List<FilePath> resultsPaths,
+                                                    final @NonNull FilePath reportPath) //NOSONAR
             throws IOException, InterruptedException {
         final ArgumentListBuilder arguments = new ArgumentListBuilder();
         arguments.add(commandline.getExecutable(launcher));
@@ -102,8 +102,8 @@ public class ReportBuilder {
         return arguments;
     }
 
-    private ArgumentListBuilder getAllure1Arguments(final @Nonnull List<FilePath> resultsPaths,
-                                                    final @Nonnull FilePath reportPath) //NOSONAR
+    private ArgumentListBuilder getAllure1Arguments(final @NonNull List<FilePath> resultsPaths,
+                                                    final @NonNull FilePath reportPath) //NOSONAR
             throws IOException, InterruptedException {
         final ArgumentListBuilder arguments = new ArgumentListBuilder();
         arguments.add(commandline.getExecutable(launcher));

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/config/AllureReportConfig.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/config/AllureReportConfig.java
@@ -15,11 +15,11 @@
  */
 package ru.yandex.qatools.allure.jenkins.config;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -78,7 +78,7 @@ public class AllureReportConfig implements Serializable {
         return commandline;
     }
 
-    @Nonnull
+    @NonNull
     @SuppressWarnings("deprecation")
     public List<ResultsConfig> getResults() {
         if (StringUtils.isNotBlank(this.resultsPattern)) {

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/tools/AllureCommandlineInstallation.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/tools/AllureCommandlineInstallation.java
@@ -15,6 +15,7 @@
  */
 package ru.yandex.qatools.allure.jenkins.tools;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.Functions;
@@ -33,7 +34,6 @@ import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import ru.yandex.qatools.allure.jenkins.Messages;
 
-import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -59,11 +59,11 @@ public class AllureCommandlineInstallation extends ToolInstallation
     }
 
     @SuppressWarnings("TrailingComment")
-    public String getExecutable(final @Nonnull Launcher launcher) throws InterruptedException, IOException { //NOSONAR
+    public String getExecutable(final @NonNull Launcher launcher) throws InterruptedException, IOException { //NOSONAR
         return launcher.getChannel().call(new GetExecutable(getHome()));
     }
 
-    public String getMajorVersion(final @Nonnull Launcher launcher) throws InterruptedException, IOException {
+    public String getMajorVersion(final @NonNull Launcher launcher) throws InterruptedException, IOException {
         return launcher.getChannel().call(new GetMajorVersion(getHome()));
     }
 
@@ -100,12 +100,12 @@ public class AllureCommandlineInstallation extends ToolInstallation
     }
 
     @Override
-    public AllureCommandlineInstallation forEnvironment(final @Nonnull EnvVars environment) {
+    public AllureCommandlineInstallation forEnvironment(final @NonNull EnvVars environment) {
         return new AllureCommandlineInstallation(getName(), environment.expand(getHome()), getProperties().toList());
     }
 
     @Override
-    public AllureCommandlineInstallation forNode(final @Nonnull Node node,
+    public AllureCommandlineInstallation forNode(final @NonNull Node node,
                                                  final TaskListener log)
             throws IOException, InterruptedException {
         return new AllureCommandlineInstallation(getName(), translateFor(node, log), getProperties().toList());
@@ -161,7 +161,7 @@ public class AllureCommandlineInstallation extends ToolInstallation
         }
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return Messages.AllureCommandlineInstallation_DisplayName();
         }

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/tools/AllureCommandlineInstaller.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/tools/AllureCommandlineInstaller.java
@@ -15,13 +15,12 @@
  */
 package ru.yandex.qatools.allure.jenkins.tools;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
 import hudson.tools.DownloadFromUrlInstaller;
 import hudson.tools.ToolInstallation;
 import org.kohsuke.stapler.DataBoundConstructor;
 import ru.yandex.qatools.allure.jenkins.Messages;
-
-import javax.annotation.Nonnull;
 
 /**
  * @author Artem Eroshenko {@literal <eroshenkoam@yandex-team.ru>}
@@ -42,7 +41,7 @@ public class AllureCommandlineInstaller extends DownloadFromUrlInstaller {
             .DescriptorImpl<AllureCommandlineInstaller> { //NOSONAR
 
         @Override
-        @Nonnull
+        @NonNull
         public String getDisplayName() {
             return Messages.AllureCommandlineInstaller_DisplayName();
         }

--- a/src/main/java/ru/yandex/qatools/allure/jenkins/utils/BuildUtils.java
+++ b/src/main/java/ru/yandex/qatools/allure/jenkins/utils/BuildUtils.java
@@ -15,6 +15,7 @@
  */
 package ru.yandex.qatools.allure.jenkins.utils;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -27,8 +28,7 @@ import hudson.tools.ToolInstallation;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.util.Objects;
 
@@ -43,9 +43,9 @@ public final class BuildUtils {
     @SuppressWarnings({"ParameterAssignment", "PMD.AvoidReassigningParameters"})
     public static <T extends ToolInstallation & EnvironmentSpecific<T> & NodeSpecific<T>> T setUpTool(
             @Nullable T tool,
-            final @Nonnull Launcher launcher,
-            final @Nonnull TaskListener listener,
-            final @Nonnull EnvVars env)
+            final @NonNull Launcher launcher,
+            final @NonNull TaskListener listener,
+            final @NonNull EnvVars env)
             throws IOException, InterruptedException {
 
         if (tool == null) {


### PR DESCRIPTION
## Replace JSR-305 annotations with spotbugs annotations

Annotations for Nonnull, CheckForNull, and several others were proposed for Java as part of dormant Java specification request JSR-305. The proposal never became a part of standard Java.

Jenkins plugins should switch from using JSR-305 annotations to use Spotbugs annotations that provide the same semantics.

The [mailing list discussion](https://groups.google.com/g/jenkinsci-dev/c/uE1wwtVi1W0/m/gLxdEJmlBQAJ) from James Nord describes the affected annotations and why they should be replaced with annotations that are actively maintained.

The ["Improve a plugin" tutorial](https://www.jenkins.io/doc/developer/tutorial-improve/replace-jsr-305-annotations/) provides instructions to perform this change.

An [OpenRewrite recipe](https://docs.openrewrite.org/recipes/jenkins/javaxannotationstospotbugs) is also available and is even better than the instructions.

### Testing done

Confirmed that automated tests pass on my Linux computer with Java 21 after the change.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
