### PR TITLE
chore: upgrade allure-commandline to 2.35.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/allure-plugin</gitHubRepo>
         <jenkins.version>2.462.1</jenkins.version>
-        <allureCommandline.version>2.21.0</allureCommandline.version>
+        <allureCommandline.version>2.35.1</allureCommandline.version>
         <truezip.version>7.7.10</truezip.version>
     </properties>
 


### PR DESCRIPTION
chore: upgrade allure-commandline to 2.35.1

The new Allure result schema introduced a breaking change. Updating the command-line tool restores compatibility with the updated schema and prevents failures during report generation.

Closes Issue: https://github.com/jenkinsci/allure-plugin/issues/392
