### PR TITLE
Increase coverage for publisher, archive, and report browsing flows

### DIFF
--- a/src/main/java/org/allurereport/jenkins/AllureReportBuildAction.java
+++ b/src/main/java/org/allurereport/jenkins/AllureReportBuildAction.java
@@ -46,6 +46,8 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.ref.WeakReference;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.NoSuchElementException;
@@ -336,6 +338,23 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
         response.sendError(HttpServletResponse.SC_NOT_FOUND, "Allure index.html not found");
     }
 
+    private static String decodeAndValidatePath(final String path,
+                                                final StaplerResponse response) throws IOException {
+        final String decodedPath;
+        try {
+            decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException ignored) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, ILLEGAL_PATH);
+            return null;
+        }
+
+        if (decodedPath.contains(PATH_TRAVERSAL)) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST, ILLEGAL_PATH);
+            return null;
+        }
+        return decodedPath;
+    }
+
     private static final class DirectoryReportBrowser implements HttpResponse {
 
         private final FilePath baseDirectory;
@@ -371,14 +390,14 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
             if (rest == null) {
                 rest = "";
             }
+            rest = decodeAndValidatePath(rest, response);
+            if (rest == null) {
+                return null;
+            }
             if (rest.isEmpty() || SLASH.equals(rest)) {
                 rest = INDEX_HTML;
             } else if (rest.startsWith(SLASH)) {
                 rest = rest.substring(1);
-            }
-            if (rest.contains(PATH_TRAVERSAL)) {
-                response.sendError(HttpServletResponse.SC_BAD_REQUEST, ILLEGAL_PATH);
-                return null;
             }
             return rest;
         }
@@ -485,9 +504,9 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
         }
 
         private String initialZipPath(final StaplerRequest req, final StaplerResponse rsp) throws IOException {
-            final String rest = req.getRestOfPath() == null ? "" : req.getRestOfPath();
-            if (rest.contains(PATH_TRAVERSAL)) {
-                rsp.sendError(HttpServletResponse.SC_BAD_REQUEST, ILLEGAL_PATH);
+            final String rawRest = req.getRestOfPath() == null ? "" : req.getRestOfPath();
+            final String rest = decodeAndValidatePath(rawRest, rsp);
+            if (rest == null) {
                 return null;
             }
             return rest.isEmpty() ? SLASH + INDEX_HTML : rest;

--- a/src/test/java/org/allurereport/jenkins/AllureReportBuildActionIT.java
+++ b/src/test/java/org/allurereport/jenkins/AllureReportBuildActionIT.java
@@ -1,0 +1,144 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import org.allurereport.jenkins.testdata.TestUtils;
+import org.allurereport.jenkins.utils.AllureReportArchiveSource;
+import org.allurereport.jenkins.utils.AllureReportArchiveSourceFactory;
+import org.htmlunit.WebRequest;
+import org.htmlunit.WebResponse;
+import org.htmlunit.html.HtmlPage;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+
+import static org.allurereport.jenkins.testdata.TestUtils.createAllurePublisher;
+import static org.allurereport.jenkins.testdata.TestUtils.getSimpleFileScm;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AllureReportBuildActionIT {
+
+    private static final String RESULTS_DIR = "allure-results";
+    private static final String INDEX_ENTRY = "allure-report/index.html";
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @ClassRule
+    public static JenkinsRule jRule = new JenkinsRule();
+
+    @ClassRule
+    public static TemporaryFolder folder = new TemporaryFolder();
+
+    private static String commandline;
+    private static String jdk;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        jdk = TestUtils.getJdk(jRule).getName();
+        commandline = TestUtils.getAllureCommandline(jRule, folder).getName();
+    }
+
+    @Test
+    public void shouldRenderBuildBadgeAndServeReportFromArchivedZip() throws Exception {
+        final FreeStyleBuild build = buildSingleReportBuild();
+        final JenkinsRule.WebClient webClient = jRule.createWebClient().withJavaScriptEnabled(false);
+
+        final HtmlPage buildPage = webClient.getPage(build);
+        assertThat(buildPage.getByXPath("//a[contains(@href, '/allure')]")).isNotEmpty();
+        assertThat(new File(build.getRootDir(), "allure-report")).doesNotExist();
+
+        final WebResponse response = webClient.loadWebResponse(
+                new WebRequest(new URL(jRule.getURL(), build.getUrl() + "allure/index.html"))
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getContentAsString()).isEqualTo(readArchivedEntry(build, INDEX_ENTRY));
+    }
+
+    @Test
+    public void shouldDownloadIndexFromArchivedZip() throws Exception {
+        final FreeStyleBuild build = buildSingleReportBuild();
+        final JenkinsRule.WebClient webClient = jRule.createWebClient().withJavaScriptEnabled(false);
+
+        final WebResponse response = webClient.loadWebResponse(
+                new WebRequest(new URL(jRule.getURL(), build.getUrl() + "allure/downloadIndex"))
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getResponseHeaderValue("Content-Disposition"))
+                .contains("attachment; filename=\"index.html\"");
+        assertThat(response.getContentAsString()).isEqualTo(readArchivedEntry(build, INDEX_ENTRY));
+    }
+
+    @Test
+    public void shouldRejectPathTraversalRequests() throws Exception {
+        final FreeStyleBuild build = buildSingleReportBuild();
+        final JenkinsRule.WebClient webClient = jRule.createWebClient().withJavaScriptEnabled(false);
+
+        webClient.assertFails(build.getUrl() + "allure/..;/secret.txt", 400);
+    }
+
+    @Test
+    public void shouldExposeGraphEndpointsAfterTwoReportBuilds() throws Exception {
+        final FreeStyleProject project = createProject();
+        project.getPublishersList().add(createAllurePublisher(jdk, commandline, RESULTS_DIR));
+
+        jRule.buildAndAssertSuccess(project);
+        final FreeStyleBuild second = jRule.buildAndAssertSuccess(project);
+        final JenkinsRule.WebClient webClient = jRule.createWebClient().withJavaScriptEnabled(false);
+
+        final WebResponse graph = webClient.loadWebResponse(
+                new WebRequest(new URL(jRule.getURL(), second.getUrl() + "allure/graph"))
+        );
+        final WebResponse graphMap = webClient.loadWebResponse(
+                new WebRequest(new URL(jRule.getURL(), second.getUrl() + "allure/graphMap"))
+        );
+
+        assertThat(graph.getStatusCode()).isEqualTo(200);
+        assertThat(graph.getContentType()).isEqualTo("image/png");
+        assertThat(graphMap.getStatusCode()).isEqualTo(200);
+        assertThat(graphMap.getContentAsString()).contains("<area");
+    }
+
+    private FreeStyleBuild buildSingleReportBuild() throws Exception {
+        final FreeStyleProject project = createProject();
+        project.getPublishersList().add(createAllurePublisher(jdk, commandline, RESULTS_DIR));
+        return jRule.buildAndAssertSuccess(project);
+    }
+
+    private FreeStyleProject createProject() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        project.setScm(getSimpleFileScm("sample-testsuite.xml", RESULTS_DIR + "/sample-testsuite.xml"));
+        return project;
+    }
+
+    private String readArchivedEntry(final FreeStyleBuild build, final String entryPath) throws Exception {
+        try (AllureReportArchiveSource source = AllureReportArchiveSourceFactory.forRun(build);
+             InputStream inputStream = source.openEntry(entryPath)) {
+            return new String(inputStream.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+        }
+    }
+}

--- a/src/test/java/org/allurereport/jenkins/AllureReportProjectActionIT.java
+++ b/src/test/java/org/allurereport/jenkins/AllureReportProjectActionIT.java
@@ -1,0 +1,86 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import org.allurereport.jenkins.testdata.TestUtils;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.allurereport.jenkins.testdata.TestUtils.createAllurePublisher;
+import static org.allurereport.jenkins.testdata.TestUtils.getSimpleFileScm;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AllureReportProjectActionIT {
+
+    private static final String RESULTS_DIR = "allure-results";
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @ClassRule
+    public static JenkinsRule jRule = new JenkinsRule();
+
+    @ClassRule
+    public static TemporaryFolder folder = new TemporaryFolder();
+
+    private static String commandline;
+    private static String jdk;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        jdk = TestUtils.getJdk(jRule).getName();
+        commandline = TestUtils.getAllureCommandline(jRule, folder).getName();
+    }
+
+    @Test
+    public void shouldNotBuildGraphWithSingleAllureBuild() throws Exception {
+        final FreeStyleProject project = createProject();
+        project.getPublishersList().add(createAllurePublisher(jdk, commandline, RESULTS_DIR));
+
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+        final AllureReportProjectAction action = new AllureReportProjectAction(project);
+
+        assertThat(action.getLastAllureBuildAction()).isNotNull();
+        assertThat(action.getLastAllureBuildAction().getBuildNumber()).isEqualTo(build.getId());
+        assertThat(action.isCanBuildGraph()).isFalse();
+    }
+
+    @Test
+    public void shouldReturnLastAllureBuildActionAndEnableGraphAfterTwoBuilds() throws Exception {
+        final FreeStyleProject project = createProject();
+        project.getPublishersList().add(createAllurePublisher(jdk, commandline, RESULTS_DIR));
+
+        jRule.buildAndAssertSuccess(project);
+        final FreeStyleBuild second = jRule.buildAndAssertSuccess(project);
+        final AllureReportProjectAction action = new AllureReportProjectAction(project);
+
+        assertThat(action.getLastAllureBuildAction()).isNotNull();
+        assertThat(action.getLastAllureBuildAction().getBuildNumber()).isEqualTo(second.getId());
+        assertThat(action.isCanBuildGraph()).isTrue();
+    }
+
+    private FreeStyleProject createProject() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        project.setScm(getSimpleFileScm("sample-testsuite.xml", RESULTS_DIR + "/sample-testsuite.xml"));
+        return project;
+    }
+}

--- a/src/test/java/org/allurereport/jenkins/AllureReportPublisherDescriptorTest.java
+++ b/src/test/java/org/allurereport/jenkins/AllureReportPublisherDescriptorTest.java
@@ -1,0 +1,81 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins;
+
+import org.allurereport.jenkins.tools.AllureCommandlineInstallation;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AllureReportPublisherDescriptorTest {
+
+    private static final String FIRST = "First";
+    private static final String SECOND = "Second";
+    private static final String DEFAULT = "Default";
+
+    @Rule
+    public JenkinsRule jRule = new JenkinsRule();
+
+    @Test
+    public void getCommandlineInstallationReturnsNamedInstallation() {
+        final AllureReportPublisherDescriptor descriptor = descriptor();
+        final AllureCommandlineInstallation first = installation(FIRST);
+        final AllureCommandlineInstallation second = installation(SECOND);
+        jRule.jenkins.getDescriptorByType(AllureCommandlineInstallation.DescriptorImpl.class)
+                .setInstallations(first, second);
+
+        assertThat(descriptor.getCommandlineInstallation(SECOND)).isEqualTo(second);
+    }
+
+    @Test
+    public void getCommandlineInstallationReturnsNullForBlankAndUnknownNames() {
+        final AllureReportPublisherDescriptor descriptor = descriptor();
+        jRule.jenkins.getDescriptorByType(AllureCommandlineInstallation.DescriptorImpl.class)
+                .setInstallations(installation(DEFAULT));
+
+        assertThat(descriptor.getCommandlineInstallation("")).isNull();
+        assertThat(descriptor.getCommandlineInstallation("missing")).isNull();
+    }
+
+    @Test
+    public void getDefaultCommandlineInstallationReturnsOnlyInstallation() {
+        final AllureReportPublisherDescriptor descriptor = descriptor();
+        final AllureCommandlineInstallation installation = installation(DEFAULT);
+        jRule.jenkins.getDescriptorByType(AllureCommandlineInstallation.DescriptorImpl.class)
+                .setInstallations(installation);
+
+        assertThat(descriptor.getDefaultCommandlineInstallation()).isEqualTo(installation);
+    }
+
+    @Test
+    public void getDefaultCommandlineInstallationReturnsNullWhenMultipleInstallationsExist() {
+        final AllureReportPublisherDescriptor descriptor = descriptor();
+        jRule.jenkins.getDescriptorByType(AllureCommandlineInstallation.DescriptorImpl.class)
+                .setInstallations(installation(FIRST), installation(SECOND));
+
+        assertThat(descriptor.getDefaultCommandlineInstallation()).isNull();
+    }
+
+    private AllureReportPublisherDescriptor descriptor() {
+        return jRule.jenkins.getDescriptorByType(AllureReportPublisherDescriptor.class);
+    }
+
+    private AllureCommandlineInstallation installation(final String name) {
+        return new AllureCommandlineInstallation(name, "/tmp/" + name, JenkinsRule.NO_PROPERTIES);
+    }
+}

--- a/src/test/java/org/allurereport/jenkins/AllureReportPublisherIT.java
+++ b/src/test/java/org/allurereport/jenkins/AllureReportPublisherIT.java
@@ -1,0 +1,138 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import org.allurereport.jenkins.config.ResultPolicy;
+import org.allurereport.jenkins.testdata.TestUtils;
+import org.allurereport.jenkins.utils.AllureReportArchiveSource;
+import org.allurereport.jenkins.utils.AllureReportArchiveSourceFactory;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.InputStream;
+import java.util.List;
+
+import static org.allurereport.jenkins.testdata.TestUtils.createAllurePublisher;
+import static org.allurereport.jenkins.testdata.TestUtils.getSimpleFileScm;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AllureReportPublisherIT {
+
+    private static final String RESULTS_DIR = "allure-results";
+    private static final String SAMPLE_PASSED = "sample-testsuite.xml";
+    private static final String SAMPLE_FAILED = "sample-testsuite-with-failed.xml";
+
+    @ClassRule
+    public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @ClassRule
+    public static JenkinsRule jRule = new JenkinsRule();
+
+    @ClassRule
+    public static TemporaryFolder folder = new TemporaryFolder();
+
+    private static String commandline;
+    private static String jdk;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        jdk = TestUtils.getJdk(jRule).getName();
+        commandline = TestUtils.getAllureCommandline(jRule, folder).getName();
+    }
+
+    @Test
+    public void shouldMarkBuildFailedWhenFailureThresholdCountIsReached() throws Exception {
+        final FreeStyleProject project = createProject(SAMPLE_FAILED);
+        final AllureReportPublisher publisher = createAllurePublisher(jdk, commandline, RESULTS_DIR);
+        publisher.setFailureThresholdCount(1);
+        project.getPublishersList().add(publisher);
+
+        final FreeStyleBuild build = jRule.assertBuildStatus(Result.FAILURE, project.scheduleBuild2(0));
+
+        assertThat(build.getAction(AllureReportBuildAction.class)).isNotNull();
+    }
+
+    @Test
+    public void shouldLeaveBuildResultUnchangedWhenResultPolicyIsLeaveAsIs() throws Exception {
+        final FreeStyleProject project = createProject(SAMPLE_FAILED);
+        final AllureReportPublisher publisher = createAllurePublisher(jdk, commandline, RESULTS_DIR);
+        publisher.setResultPolicy(ResultPolicy.LEAVE_AS_IS);
+        project.getPublishersList().add(publisher);
+
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+
+        assertThat(build.getAction(AllureReportBuildAction.class)).isNotNull();
+        assertThat(build.getResult()).isEqualTo(Result.SUCCESS);
+    }
+
+    @Test
+    public void shouldArchiveCustomReportPathUsingLeafDirectoryName() throws Exception {
+        final FreeStyleProject project = createProject(SAMPLE_PASSED);
+        final AllureReportPublisher publisher = createAllurePublisher(jdk, commandline, RESULTS_DIR);
+        publisher.setReport("target/custom-report");
+        project.getPublishersList().add(publisher);
+
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+
+        try (AllureReportArchiveSource source = AllureReportArchiveSourceFactory.forRun(build)) {
+            final List<String> entries = source.listEntries("custom-report");
+            assertThat(entries).contains("custom-report/index.html");
+        }
+    }
+
+    @Test
+    public void shouldCarryHistoryAcrossBuilds() throws Exception {
+        final FreeStyleProject project = createProject(SAMPLE_PASSED);
+        project.getPublishersList().add(createAllurePublisher(jdk, commandline, RESULTS_DIR));
+
+        final FreeStyleBuild first = jRule.buildAndAssertSuccess(project);
+        final FreeStyleBuild second = jRule.buildAndAssertSuccess(project);
+
+        final int firstHistoryItems = historyItems(first);
+        final int secondHistoryItems = historyItems(second);
+
+        assertThat(firstHistoryItems).isGreaterThan(0);
+        assertThat(secondHistoryItems).isGreaterThan(firstHistoryItems);
+    }
+
+    private FreeStyleProject createProject(final String resourceName) throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        project.setScm(getSimpleFileScm(resourceName, RESULTS_DIR + "/sample-testsuite.xml"));
+        return project;
+    }
+
+    private int historyItems(final FreeStyleBuild build) throws Exception {
+        final ObjectMapper mapper = new ObjectMapper();
+        try (AllureReportArchiveSource source = AllureReportArchiveSourceFactory.forRun(build);
+             InputStream inputStream = source.openEntry("allure-report/history/history.json")) {
+            final JsonNode root = mapper.readTree(inputStream);
+            int items = 0;
+            for (JsonNode testHistory : root) {
+                items += testHistory.path("items").size();
+            }
+            return items;
+        }
+    }
+}

--- a/src/test/java/org/allurereport/jenkins/JobDslIT.java
+++ b/src/test/java/org/allurereport/jenkins/JobDslIT.java
@@ -20,6 +20,7 @@ import hudson.model.FreeStyleProject;
 import hudson.tasks.Publisher;
 import hudson.util.DescribableList;
 import org.allurereport.jenkins.config.PropertyConfig;
+import org.allurereport.jenkins.config.ResultPolicy;
 import org.allurereport.jenkins.config.ResultsConfig;
 import org.apache.commons.io.IOUtils;
 import org.junit.Rule;
@@ -72,6 +73,10 @@ public class JobDslIT {
         assertThat(allureReportPublisher.getIncludeProperties()).isEqualTo(Boolean.TRUE);
 
         assertThat(allureReportPublisher.getConfigPath()).isEqualTo(null);
+        assertThat(allureReportPublisher.getResultPolicy()).isEqualTo(ResultPolicy.FAILURE_IF_FAILED_OR_BROKEN);
+        assertThat(allureReportPublisher.getUnstableThresholdPercent()).isEqualTo(50);
+        assertThat(allureReportPublisher.getFailureThresholdCount()).isEqualTo(2);
+        assertThat(allureReportPublisher.getReportName()).isEqualTo("Team Allure");
     }
 
     private void buildJob() throws Exception {

--- a/src/test/java/org/allurereport/jenkins/ReportBuilderTest.java
+++ b/src/test/java/org/allurereport/jenkins/ReportBuilderTest.java
@@ -1,0 +1,196 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins;
+
+import hudson.EnvVars;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.util.ArgumentListBuilder;
+import hudson.util.StreamTaskListener;
+import org.allurereport.jenkins.tools.AllureInstallation;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReportBuilderTest {
+
+    private static final String VERSION_3 = "3.1.0";
+    private static final String EXECUTABLE = "/opt/allure/bin/allure";
+    private static final String GENERATE = "generate";
+    private static final String CLEAN = "-c";
+    private static final String OUTPUT = "-o";
+    private static final String CONFIG = "--config";
+    private static final String SINGLE_FILE = "--single-file";
+    private static final String QUOTE = "\"";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void parseMajorDefaultsToAllure2ForNullAndUnparseableVersions() throws Exception {
+        assertThat(parseMajor(null)).isEqualTo(2);
+        assertThat(parseMajor("not-a-version")).isEqualTo(2);
+    }
+
+    @Test
+    public void parseMajorExtractsFirstNumericVersionComponent() throws Exception {
+        assertThat(parseMajor(VERSION_3)).isEqualTo(3);
+        assertThat(parseMajor(" 1.4.24 ")).isEqualTo(1);
+        assertThat(parseMajor("v2.32.0")).isEqualTo(2);
+    }
+
+    @Test
+    public void allure2ArgumentsIncludeCleanConfigAndSingleFileFlags() throws Exception {
+        final FilePath results1 = new FilePath(folder.newFolder("results-one"));
+        final FilePath results2 = new FilePath(folder.newFolder("results-two"));
+        final FilePath report = new FilePath(folder.newFolder("report-dir"));
+        final FilePath config = new FilePath(folder.newFile("allure.yaml"));
+
+        final ArgumentListBuilder arguments = invokeArguments(
+                "2.35.1",
+                Arrays.asList(results1, results2),
+                report,
+                config,
+                true
+        );
+
+        assertThat(arguments.toList()).containsExactly(
+                EXECUTABLE,
+                GENERATE,
+                results1.getRemote(),
+                results2.getRemote(),
+                CLEAN,
+                OUTPUT,
+                report.getRemote(),
+                CONFIG,
+                config.getRemote(),
+                SINGLE_FILE
+        );
+    }
+
+    @Test
+    public void allure3ArgumentsDoNotIncludeCleanFlag() throws Exception {
+        final FilePath results = new FilePath(folder.newFolder("results"));
+        final FilePath report = new FilePath(folder.newFolder("report"));
+
+        final ArgumentListBuilder arguments = invokeArguments(
+                VERSION_3,
+                Arrays.asList(results),
+                report,
+                null,
+                false
+        );
+
+        assertThat(arguments.toList()).containsExactly(
+                EXECUTABLE,
+                GENERATE,
+                results.getRemote(),
+                OUTPUT,
+                report.getRemote()
+        );
+        assertThat(arguments.toList()).doesNotContain(CLEAN, CONFIG, SINGLE_FILE);
+    }
+
+    @Test
+    public void allure1ArgumentsQuotePathsWithSpaces() throws Exception {
+        final FilePath results = new FilePath(folder.newFolder("results with spaces"));
+        final FilePath report = new FilePath(folder.newFolder("report with spaces"));
+
+        final ArgumentListBuilder arguments = invokeArguments(
+                "1.5.4",
+                Arrays.asList(results),
+                report,
+                null,
+                false
+        );
+
+        assertThat(arguments.toList()).containsExactly(
+                EXECUTABLE,
+                GENERATE,
+                QUOTE + results.getRemote() + QUOTE,
+                OUTPUT,
+                QUOTE + report.getRemote() + QUOTE
+        );
+        assertThat(arguments.toStringWithQuote())
+                .contains(QUOTE + results.getRemote() + QUOTE)
+                .contains(QUOTE + report.getRemote() + QUOTE);
+    }
+
+    private int parseMajor(final String version) throws Exception {
+        final Method method = ReportBuilder.class.getDeclaredMethod("parseMajor", String.class);
+        method.setAccessible(true);
+        return (Integer) method.invoke(null, version);
+    }
+
+    private ArgumentListBuilder invokeArguments(final String version,
+                                                final List<FilePath> resultsPaths,
+                                                final FilePath reportPath,
+                                                final FilePath configFilePath,
+                                                final boolean singleFile) throws Exception {
+        final StreamTaskListener listener = new StreamTaskListener(System.out, StandardCharsets.UTF_8);
+        final Launcher launcher = new Launcher.LocalLauncher(listener);
+        final FilePath workspace = new FilePath(folder.newFolder("workspace-" + version.replace('.', '-')));
+        final ReportBuilder builder = new ReportBuilder(
+                launcher,
+                listener,
+                workspace,
+                new EnvVars(),
+                new FakeAllureInstallation(version)
+        );
+
+        if (configFilePath != null) {
+            builder.setConfigFilePath(configFilePath);
+        }
+        builder.setSingleFile(singleFile);
+
+        final Method method = ReportBuilder.class.getDeclaredMethod(
+                "getArguments", String.class, List.class, FilePath.class
+        );
+        method.setAccessible(true);
+        return (ArgumentListBuilder) method.invoke(builder, version, resultsPaths, reportPath);
+    }
+
+    private static final class FakeAllureInstallation implements AllureInstallation {
+
+        private final String version;
+
+        private FakeAllureInstallation(final String version) {
+            this.version = version;
+        }
+
+        @Override
+        public String getExecutable(final Launcher launcher) {
+            return EXECUTABLE;
+        }
+
+        @Override
+        public String getMajorVersion(final Launcher launcher) {
+            return version;
+        }
+
+        @Override
+        public String getName() {
+            return "fake";
+        }
+    }
+}

--- a/src/test/java/org/allurereport/jenkins/ReportGenerateIT.java
+++ b/src/test/java/org/allurereport/jenkins/ReportGenerateIT.java
@@ -91,7 +91,7 @@ public class ReportGenerateIT {
         final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
 
         assertThat(build.getArtifacts())
-                .as("An artifact for allure report should be created in the artifacts dir for the build")
+                .as("Allure report and summary artifacts should be archived for the build")
                 .extracting(Run.Artifact::getFileName)
                 .containsExactlyInAnyOrder("allure-report.zip", "allure-summary.json");
     }

--- a/src/test/java/org/allurereport/jenkins/testdata/TestUtils.java
+++ b/src/test/java/org/allurereport/jenkins/testdata/TestUtils.java
@@ -35,6 +35,8 @@ import java.util.List;
 
 public final class TestUtils {
 
+    private static final String ALLURE_COMMANDLINE_ZIP = "allure-commandline.zip";
+
     private TestUtils() {
     }
 
@@ -57,17 +59,19 @@ public final class TestUtils {
     }
 
     private static URL getAllureCommandlineResource() throws IOException {
-        final URL classpathResource = TestUtils.class.getClassLoader().getResource("allure-commandline.zip");
+        final URL classpathResource = TestUtils.class.getClassLoader().getResource(ALLURE_COMMANDLINE_ZIP);
         if (classpathResource != null) {
             return classpathResource;
         }
 
-        final Path fallbackPath = Paths.get("target", "resources", "test", "allure-commandline.zip");
+        final Path fallbackPath = Paths.get("target", "resources", "test", ALLURE_COMMANDLINE_ZIP);
         if (Files.exists(fallbackPath)) {
             return fallbackPath.toUri().toURL();
         }
 
-        throw new IOException("Cannot locate allure-commandline.zip in test classpath or target/resources/test");
+        throw new IOException(
+                "Cannot locate " + ALLURE_COMMANDLINE_ZIP + " in test classpath or target/resources/test"
+        );
     }
 
     public static SCM getSimpleFileScm(final String resourceName,

--- a/src/test/java/org/allurereport/jenkins/testdata/TestUtils.java
+++ b/src/test/java/org/allurereport/jenkins/testdata/TestUtils.java
@@ -26,7 +26,10 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.SingleFileSCM;
 
 import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 
@@ -43,8 +46,7 @@ public final class TestUtils {
                                                                      final TemporaryFolder folder) throws Exception {
         final Path allureHome = folder.newFolder("some spaces in here").toPath();
         final FilePath allure = jRule.jenkins.getRootPath().createTempFile("allure", "zip");
-        //noinspection ConstantConditions
-        allure.copyFrom(TestUtils.class.getClassLoader().getResource("allure-commandline.zip"));
+        allure.copyFrom(getAllureCommandlineResource());
         allure.unzip(new FilePath(allureHome.toFile()));
 
         final AllureCommandlineInstallation installation = new AllureCommandlineInstallation(
@@ -52,6 +54,20 @@ public final class TestUtils {
         jRule.jenkins.getDescriptorByType(AllureCommandlineInstallation.DescriptorImpl.class)
                 .setInstallations(installation);
         return installation;
+    }
+
+    private static URL getAllureCommandlineResource() throws IOException {
+        final URL classpathResource = TestUtils.class.getClassLoader().getResource("allure-commandline.zip");
+        if (classpathResource != null) {
+            return classpathResource;
+        }
+
+        final Path fallbackPath = Paths.get("target", "resources", "test", "allure-commandline.zip");
+        if (Files.exists(fallbackPath)) {
+            return fallbackPath.toUri().toURL();
+        }
+
+        throw new IOException("Cannot locate allure-commandline.zip in test classpath or target/resources/test");
     }
 
     public static SCM getSimpleFileScm(final String resourceName,

--- a/src/test/java/org/allurereport/jenkins/utils/AllureSummaryExtractorTest.java
+++ b/src/test/java/org/allurereport/jenkins/utils/AllureSummaryExtractorTest.java
@@ -1,0 +1,217 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.utils;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.StreamBuildListener;
+import jenkins.util.VirtualFile;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AllureSummaryExtractorTest {
+
+    private static final String SUMMARY_ARTIFACT = "allure-summary.json";
+    private static final String REPORT_PATH = "allure-report";
+    private static final String SUMMARY_ENTRY = "allure-report/widgets/summary.json";
+
+    @Rule
+    public JenkinsRule jRule = new JenkinsRule();
+
+    @Test
+    public void extractFromSummaryJsonReadsStatisticPayload() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+        archiveArtifacts(project, build, mapOf(
+                SUMMARY_ARTIFACT,
+                summaryJson(3, 1, 2, 4, 5)
+        ));
+
+        final VirtualFile artifact = build.getArtifactManager().root().child(SUMMARY_ARTIFACT);
+        final BuildSummary summary = AllureSummaryExtractor.extractFromSummaryJson(artifact);
+
+        assertCounts(summary, 3, 1, 2, 4, 5);
+    }
+
+    @Test
+    public void extractReadsAllure2SummaryFromZipWhenNoSummaryArtifactExists() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+        archiveZip(project, build, mapOf(
+                SUMMARY_ENTRY,
+                summaryJson(4, 2, 1, 0, 3)
+        ));
+
+        final BuildSummary summary = AllureSummaryExtractor.extract(build, REPORT_PATH, false);
+
+        assertCounts(summary, 4, 2, 1, 0, 3);
+    }
+
+    @Test
+    public void extractReadsAllure3AwesomeStatisticFromZip() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+        archiveZip(project, build, mapOf(
+                "allure-report/awesome/widgets/statistic.json",
+                statisticJson(6, 1, 0, 2, 3)
+        ));
+
+        final BuildSummary summary = AllureSummaryExtractor.extract(build, REPORT_PATH, true);
+
+        assertCounts(summary, 6, 1, 0, 2, 3);
+    }
+
+    @Test
+    public void extractFallsBackToUnpackedDirectoryWhenArchiveIsMissing() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+        writeFile(
+                new FilePath(build.getRootDir()).child(SUMMARY_ENTRY),
+                summaryJson(8, 0, 1, 2, 0)
+        );
+
+        final BuildSummary summary = AllureSummaryExtractor.extract(build, REPORT_PATH, false);
+
+        assertCounts(summary, 8, 0, 1, 2, 0);
+    }
+
+    @Test
+    public void extractReturnsEmptySummaryWhenNoSourcesExist() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+
+        final BuildSummary summary = AllureSummaryExtractor.extract(build, REPORT_PATH, false);
+
+        assertCounts(summary, 0, 0, 0, 0, 0);
+    }
+
+    private void archiveArtifacts(final FreeStyleProject project,
+                                  final FreeStyleBuild build,
+                                  final Map<String, String> artifacts) throws Exception {
+        final FilePath workspace = Objects.requireNonNull(jRule.jenkins.getWorkspaceFor(project));
+        workspace.deleteRecursive();
+        workspace.mkdirs();
+
+        final Map<String, String> archivedPaths = new LinkedHashMap<>();
+        for (Map.Entry<String, String> artifact : artifacts.entrySet()) {
+            writeFile(workspace.child(artifact.getKey()), artifact.getValue());
+            archivedPaths.put(artifact.getKey(), artifact.getKey());
+        }
+
+        final StreamBuildListener listener = new StreamBuildListener(
+                OutputStream.nullOutputStream(), StandardCharsets.UTF_8
+        );
+        final Launcher launcher = new Launcher.LocalLauncher(listener);
+        build.pickArtifactManager().archive(workspace, launcher, listener, archivedPaths);
+    }
+
+    private void archiveZip(final FreeStyleProject project,
+                            final FreeStyleBuild build,
+                            final Map<String, String> zipEntries) throws Exception {
+        final FilePath workspace = Objects.requireNonNull(jRule.jenkins.getWorkspaceFor(project));
+        workspace.deleteRecursive();
+        workspace.mkdirs();
+
+        final FilePath zip = workspace.child(AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP);
+        try (OutputStream outputStream = zip.write(); ZipOutputStream zipOut = new ZipOutputStream(outputStream)) {
+            for (Map.Entry<String, String> entry : zipEntries.entrySet()) {
+                zipOut.putNextEntry(new ZipEntry(entry.getKey()));
+                zipOut.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
+                zipOut.closeEntry();
+            }
+        }
+
+        final StreamBuildListener listener = new StreamBuildListener(
+                OutputStream.nullOutputStream(), StandardCharsets.UTF_8
+        );
+        final Launcher launcher = new Launcher.LocalLauncher(listener);
+        build.pickArtifactManager().archive(
+                workspace,
+                launcher,
+                listener,
+                mapOf(
+                        AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP,
+                        AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP
+                )
+        );
+    }
+
+    private void writeFile(final FilePath target, final String content) throws Exception {
+        final FilePath parent = target.getParent();
+        if (parent != null) {
+            parent.mkdirs();
+        }
+        try (OutputStream outputStream = target.write()) {
+            outputStream.write(content.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    private String summaryJson(final int passed,
+                               final int failed,
+                               final int broken,
+                               final int skipped,
+                               final int unknown) {
+        return String.format(
+                "{\"statistic\":{\"passed\":%d,\"failed\":%d,\"broken\":%d,\"skipped\":%d,\"unknown\":%d}}",
+                passed, failed, broken, skipped, unknown
+        );
+    }
+
+    private String statisticJson(final int passed,
+                                 final int failed,
+                                 final int broken,
+                                 final int skipped,
+                                 final int unknown) {
+        return String.format(
+                "{\"passed\":%d,\"failed\":%d,\"broken\":%d,\"skipped\":%d,\"unknown\":%d}",
+                passed, failed, broken, skipped, unknown
+        );
+    }
+
+    private void assertCounts(final BuildSummary summary,
+                              final long passed,
+                              final long failed,
+                              final long broken,
+                              final long skipped,
+                              final long unknown) {
+        assertThat(summary.getPassedCount()).isEqualTo(passed);
+        assertThat(summary.getFailedCount()).isEqualTo(failed);
+        assertThat(summary.getBrokenCount()).isEqualTo(broken);
+        assertThat(summary.getSkipCount()).isEqualTo(skipped);
+        assertThat(summary.getUnknownCount()).isEqualTo(unknown);
+    }
+
+    private Map<String, String> mapOf(final String... keyValues) {
+        final Map<String, String> result = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            result.put(keyValues[i], keyValues[i + 1]);
+        }
+        return result;
+    }
+}

--- a/src/test/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSourceTest.java
+++ b/src/test/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSourceTest.java
@@ -1,0 +1,211 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.utils;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.StreamBuildListener;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class ArtifactManagerArchiveSourceTest {
+
+    private static final String HISTORY_ENTRY = "allure-report/history/history.json";
+    private static final String HISTORY_PREFIX = "allure-report/history";
+    private static final String CATEGORIES_ENTRY = "allure-report/history/categories.json";
+    private static final String SUMMARY_ENTRY = "allure-report/widgets/summary.json";
+    private static final String EMPTY_HISTORY = "{\"items\":[]}";
+    private static final String ZIP_HISTORY = "{\"zip\":true}";
+    private static final String EMPTY_OBJECT = "{}";
+    private static final String EMPTY_ARRAY = "[]";
+
+    @Rule
+    public JenkinsRule jRule = new JenkinsRule();
+
+    @Test
+    public void openEntryReadsDirectArtifactWithoutZip() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+        archiveArtifacts(project, build, mapOf(HISTORY_ENTRY, EMPTY_HISTORY));
+
+        try (ArtifactManagerArchiveSource source = new ArtifactManagerArchiveSource(build);
+             InputStream inputStream = source.openEntry(HISTORY_ENTRY)) {
+            assertThat(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8))
+                    .isEqualTo(EMPTY_HISTORY);
+        }
+    }
+
+    @Test
+    public void openEntryReadsZipArtifactWhenDirectArtifactIsMissing() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+        archiveZip(project, build, mapOf(HISTORY_ENTRY, ZIP_HISTORY));
+
+        try (ArtifactManagerArchiveSource source = new ArtifactManagerArchiveSource(build);
+             InputStream inputStream = source.openEntry(HISTORY_ENTRY)) {
+            assertThat(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8))
+                    .isEqualTo(ZIP_HISTORY);
+        }
+    }
+
+    @Test
+    public void listEntriesTraversesDirectArtifactsRecursively() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+        archiveArtifacts(project, build, mapOf(
+                HISTORY_ENTRY, EMPTY_OBJECT,
+                CATEGORIES_ENTRY, EMPTY_ARRAY,
+                SUMMARY_ENTRY, EMPTY_OBJECT
+        ));
+
+        try (ArtifactManagerArchiveSource source = new ArtifactManagerArchiveSource(build)) {
+            final List<String> entries = source.listEntries(HISTORY_PREFIX);
+
+            assertThat(entries).containsExactlyInAnyOrder(
+                    HISTORY_ENTRY,
+                    CATEGORIES_ENTRY
+            );
+        }
+    }
+
+    @Test
+    public void listEntriesReadsMatchingEntriesFromZipArtifact() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+        archiveZip(project, build, mapOf(
+                HISTORY_ENTRY, EMPTY_OBJECT,
+                CATEGORIES_ENTRY, EMPTY_ARRAY,
+                SUMMARY_ENTRY, EMPTY_OBJECT
+        ));
+
+        try (ArtifactManagerArchiveSource source = new ArtifactManagerArchiveSource(build)) {
+            final List<String> entries = source.listEntries(HISTORY_PREFIX);
+
+            assertThat(entries).containsExactlyInAnyOrder(
+                    HISTORY_ENTRY,
+                    CATEGORIES_ENTRY
+            );
+        }
+    }
+
+    @Test
+    public void existsReturnsTrueOnlyWhenZipArtifactIsArchived() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+        archiveZip(project, build, mapOf("allure-report/index.html", "<html/>"));
+
+        try (ArtifactManagerArchiveSource source = new ArtifactManagerArchiveSource(build)) {
+            assertThat(source.exists()).isTrue();
+        }
+    }
+
+    @Test
+    public void missingArtifactsReturnEmptyResultsAndMissingEntryError() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+
+        try (ArtifactManagerArchiveSource source = new ArtifactManagerArchiveSource(build)) {
+            assertThat(source.exists()).isFalse();
+            assertThat(source.listEntries(HISTORY_PREFIX)).isEmpty();
+            assertThatThrownBy(() -> source.openEntry(HISTORY_ENTRY))
+                    .isInstanceOf(NoSuchElementException.class)
+                    .hasMessageContaining("allure-report.zip");
+        }
+    }
+
+    private void archiveArtifacts(final FreeStyleProject project,
+                                  final FreeStyleBuild build,
+                                  final Map<String, String> artifacts) throws Exception {
+        final FilePath workspace = Objects.requireNonNull(jRule.jenkins.getWorkspaceFor(project));
+        workspace.deleteRecursive();
+        workspace.mkdirs();
+
+        final Map<String, String> archivedPaths = new LinkedHashMap<>();
+        for (Map.Entry<String, String> artifact : artifacts.entrySet()) {
+            final FilePath target = workspace.child(artifact.getKey());
+            final FilePath parent = target.getParent();
+            if (parent != null) {
+                parent.mkdirs();
+            }
+            try (OutputStream outputStream = target.write()) {
+                outputStream.write(artifact.getValue().getBytes(StandardCharsets.UTF_8));
+            }
+            archivedPaths.put(artifact.getKey(), artifact.getKey());
+        }
+
+        final StreamBuildListener listener = new StreamBuildListener(
+                OutputStream.nullOutputStream(), StandardCharsets.UTF_8
+        );
+        final Launcher launcher = new Launcher.LocalLauncher(listener);
+        build.pickArtifactManager().archive(workspace, launcher, listener, archivedPaths);
+    }
+
+    private void archiveZip(final FreeStyleProject project,
+                            final FreeStyleBuild build,
+                            final Map<String, String> zipEntries) throws Exception {
+        final FilePath workspace = Objects.requireNonNull(jRule.jenkins.getWorkspaceFor(project));
+        workspace.deleteRecursive();
+        workspace.mkdirs();
+
+        final FilePath zip = workspace.child(AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP);
+        try (OutputStream fileOut = zip.write(); ZipOutputStream zipOut = new ZipOutputStream(fileOut)) {
+            for (Map.Entry<String, String> entry : zipEntries.entrySet()) {
+                zipOut.putNextEntry(new ZipEntry(entry.getKey()));
+                zipOut.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
+                zipOut.closeEntry();
+            }
+        }
+
+        final StreamBuildListener listener = new StreamBuildListener(
+                OutputStream.nullOutputStream(), StandardCharsets.UTF_8
+        );
+        final Launcher launcher = new Launcher.LocalLauncher(listener);
+        build.pickArtifactManager().archive(
+                workspace,
+                launcher,
+                listener,
+                mapOf(
+                        AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP,
+                        AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP
+                )
+        );
+    }
+
+    private Map<String, String> mapOf(final String... keyValues) {
+        final Map<String, String> result = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            result.put(keyValues[i], keyValues[i + 1]);
+        }
+        return result;
+    }
+}

--- a/src/test/java/org/allurereport/jenkins/utils/FilePathUtilsTest.java
+++ b/src/test/java/org/allurereport/jenkins/utils/FilePathUtilsTest.java
@@ -1,0 +1,165 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.utils;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Run;
+import hudson.model.StreamBuildListener;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FilePathUtilsTest {
+
+    private static final String REPORT_PATH = "allure-report";
+    private static final String HISTORY_ENTRY = "allure-report/history/history.json";
+
+    @Rule
+    public JenkinsRule jRule = new JenkinsRule();
+
+    @Test
+    public void extractSummaryPrefersStandaloneSummaryArtifactOverZip() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+        archive(project, build, mapOf(
+                "allure-summary.json",
+                "{\"statistic\":{\"passed\":7,\"failed\":0,\"broken\":0,\"skipped\":1,\"unknown\":2}}"
+        ), mapOf(
+                "allure-report/widgets/summary.json",
+                "{\"statistic\":{\"passed\":1,\"failed\":2,\"broken\":3,\"skipped\":4,\"unknown\":5}}"
+        ));
+
+        final BuildSummary summary = FilePathUtils.extractSummary(build, REPORT_PATH, false);
+
+        assertThat(summary.getPassedCount()).isEqualTo(7);
+        assertThat(summary.getFailedCount()).isZero();
+        assertThat(summary.getSkipCount()).isEqualTo(1);
+        assertThat(summary.getUnknownCount()).isEqualTo(2);
+    }
+
+    @Test
+    public void extractSummaryReturnsEmptyWhenNoArtifactsOrDirectoriesExist() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+
+        final BuildSummary summary = FilePathUtils.extractSummary(build, REPORT_PATH, false);
+
+        assertThat(summary.getPassedCount()).isZero();
+        assertThat(summary.getFailedCount()).isZero();
+        assertThat(summary.getBrokenCount()).isZero();
+        assertThat(summary.getSkipCount()).isZero();
+        assertThat(summary.getUnknownCount()).isZero();
+    }
+
+    @Test
+    public void getPreviousRunWithHistorySkipsEmptyHistoryAndFindsNearestNonEmptyRun() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+
+        final FreeStyleBuild first = jRule.buildAndAssertSuccess(project);
+        archive(project, first, mapOf(), mapOf(
+                HISTORY_ENTRY,
+                "{\"case\":[{}]}"
+        ));
+
+        final FreeStyleBuild second = jRule.buildAndAssertSuccess(project);
+        archive(project, second, mapOf(), mapOf(
+                HISTORY_ENTRY,
+                "{}"
+        ));
+
+        final FreeStyleBuild third = jRule.buildAndAssertSuccess(project);
+
+        final Run<?, ?> previous = FilePathUtils.getPreviousRunWithHistory(third, REPORT_PATH);
+
+        assertThat(previous).isEqualTo(first);
+    }
+
+    @Test
+    public void getPreviousRunWithHistoryReturnsNullWhenNoPreviousHistoryExists() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild first = jRule.buildAndAssertSuccess(project);
+        final FreeStyleBuild second = jRule.buildAndAssertSuccess(project);
+
+        final Run<?, ?> previous = FilePathUtils.getPreviousRunWithHistory(second, REPORT_PATH);
+
+        assertThat(previous).isNull();
+    }
+
+    private void archive(final FreeStyleProject project,
+                         final FreeStyleBuild build,
+                         final Map<String, String> artifacts,
+                         final Map<String, String> zipEntries) throws Exception {
+        final FilePath workspace = Objects.requireNonNull(jRule.jenkins.getWorkspaceFor(project));
+        workspace.deleteRecursive();
+        workspace.mkdirs();
+
+        final Map<String, String> archivedPaths = new LinkedHashMap<>();
+        for (Map.Entry<String, String> artifact : artifacts.entrySet()) {
+            writeFile(workspace.child(artifact.getKey()), artifact.getValue());
+            archivedPaths.put(artifact.getKey(), artifact.getKey());
+        }
+
+        if (!zipEntries.isEmpty()) {
+            final FilePath zip = workspace.child(AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP);
+            try (OutputStream outputStream = zip.write(); ZipOutputStream zipOut = new ZipOutputStream(outputStream)) {
+                for (Map.Entry<String, String> entry : zipEntries.entrySet()) {
+                    zipOut.putNextEntry(new ZipEntry(entry.getKey()));
+                    zipOut.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
+                    zipOut.closeEntry();
+                }
+            }
+            archivedPaths.put(AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP,
+                    AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP);
+        }
+
+        final StreamBuildListener listener = new StreamBuildListener(
+                OutputStream.nullOutputStream(), StandardCharsets.UTF_8
+        );
+        final Launcher launcher = new Launcher.LocalLauncher(listener);
+        build.pickArtifactManager().archive(workspace, launcher, listener, archivedPaths);
+    }
+
+    private void writeFile(final FilePath target, final String content) throws Exception {
+        final FilePath parent = target.getParent();
+        if (parent != null) {
+            parent.mkdirs();
+        }
+        try (OutputStream outputStream = target.write()) {
+            outputStream.write(content.getBytes(StandardCharsets.UTF_8));
+        }
+    }
+
+    private Map<String, String> mapOf(final String... keyValues) {
+        final Map<String, String> result = new LinkedHashMap<>();
+        for (int i = 0; i < keyValues.length; i += 2) {
+            result.put(keyValues[i], keyValues[i + 1]);
+        }
+        return result;
+    }
+}

--- a/src/test/resources/allure.groovy
+++ b/src/test/resources/allure.groovy
@@ -5,6 +5,10 @@ freeStyleJob('allure') {
             buildFor('UNSTABLE')
             property('key', 'value')
             includeProperties(true)
+            resultPolicy('FAILURE_IF_FAILED_OR_BROKEN')
+            unstableThresholdPercent(50)
+            failureThresholdCount(2)
+            reportName('Team Allure')
         }
     }
 }


### PR DESCRIPTION
This change expands coverage around the main Allure publishing flow in Jenkins. It adds tests for report generation options, summary extraction, archived report reading, and the build and project actions that expose reports and trends in the UI. It also broadens the Job DSL coverage so newer publisher settings stay exercised alongside the existing configuration paths.

The new integration scenarios focus on the user-facing behavior that matters most: publishing a report, attaching the build action, serving the archived report back through Jenkins, exposing trend data, and carrying history forward between builds automatically. A couple of small supporting fixes were included where the new tests uncovered gaps, mainly around path handling in report browsing and making the test setup more reliable.