### PR TITLE
Split release and publish workflows, and update master references to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - '*'
   push:
     branches:
-      - 'master'
+      - 'main'
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish
+
+on:
+  release:
+    types: [ published ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: refs/tags/${{ github.event.release.tag_name }}
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+          server-id: maven.jenkins-ci.org
+          server-username: JENKINS_USERNAME
+          server-password: JENKINS_TOKEN
+      - name: "Build"
+        run: ./mvnw -B -ntp verify
+      - name: "Publish"
+        run: ./mvnw -B -ntp -DskipTests deploy
+        env:
+          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
+          JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,27 +1,65 @@
 name: Release
+run-name: Release ${{ inputs.releaseVersion }} (next ${{ inputs.nextVersion }}) by ${{ github.actor }}
 
 on:
-  release:
-    types: [ published ]
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: "The release version to publish (for example 2.36.0)"
+        required: true
+      nextVersion:
+        description: "The next development version without the -SNAPSHOT suffix"
+        required: true
+
+permissions:
+  contents: read
 
 jobs:
   triage:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
+      - name: "Check release version"
+        run: |
+          echo "${{ github.event.inputs.releaseVersion }}" | grep -Eq '^[0-9]+(\.[0-9]+)+$'
+      - name: "Check next version"
+        run: |
+          echo "${{ github.event.inputs.nextVersion }}" | grep -Eq '^[0-9]+(\.[0-9]+)+$'
       - uses: actions/checkout@v6
         with:
+          ref: ${{ github.ref_name }}
           fetch-depth: 0
-      - uses: actions/setup-java@v5
+          token: ${{ secrets.QAMETA_CI }}
+      - name: "Configure CI Git User"
+        run: |
+          git config --global user.name qameta-ci
+          git config --global user.email qameta-ci@qameta.io
+      - name: "Set release version"
+        run: |
+          sed -i -E 's#<revision>.*</revision>#<revision>${{ github.event.inputs.releaseVersion }}</revision>#' pom.xml
+          sed -i -E 's#<changelist>.*</changelist>#<changelist></changelist>#' pom.xml
+          grep -E '<revision>|<changelist>' pom.xml
+      - name: "Commit release version and create tag"
+        run: |
+          git commit -am "release ${{ github.event.inputs.releaseVersion }}"
+          git tag ${{ github.event.inputs.releaseVersion }}
+          git push origin ${{ github.event.inputs.releaseVersion }}
+      - name: "Set next development version"
+        run: |
+          sed -i -E 's#<revision>.*</revision>#<revision>${{ github.event.inputs.nextVersion }}</revision>#' pom.xml
+          sed -i -E 's#<changelist>.*</changelist>#<changelist>-SNAPSHOT</changelist>#' pom.xml
+          grep -E '<revision>|<changelist>' pom.xml
+      - name: "Commit next development version and push it"
+        run: |
+          git commit -am "set next development version ${{ github.event.inputs.nextVersion }}"
+          git push origin ${{ github.ref_name }}
+      - name: "Publish GitHub Release"
+        uses: octokit/request-action@v2.x
         with:
-          distribution: 'temurin'
-          java-version: '11'
-          cache: 'maven'
-          server-id: maven.jenkins-ci.org
-          server-username: JENKINS_USERNAME
-          server-password: JENKINS_TOKEN
-      - run: |
-          ./mvnw versions:set -DnewVersion=${GITHUB_REF:10}
-          ./mvnw deploy
+          route: POST /repos/${{ github.repository }}/releases
+          tag_name: ${{ github.event.inputs.releaseVersion }}
+          generate_release_notes: true
+          target_commitish: ${{ github.ref_name }}
         env:
-          JENKINS_USERNAME: ${{ secrets.JENKINS_USERNAME }}
-          JENKINS_TOKEN: ${{ secrets.JENKINS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.QAMETA_CI }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Allure Jenkins Plugin
 
 [![release](https://img.shields.io/github/v/release/jenkinsci/allure-plugin?style=flat)](https://github.com/jenkinsci/allure-plugin/releases/latest)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/jenkinsci/allure-plugin/build.yml?branch=master&style=flat)](https://github.com/jenkinsci/allure-plugin/actions/workflows/build.yml?query=branch%3Amaster)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/jenkinsci/allure-plugin/build.yml?branch=main&style=flat)](https://github.com/jenkinsci/allure-plugin/actions/workflows/build.yml?query=branch%3Amain)
 
 > This repository contains the source code of the Allure plugin for Jenkins.
 

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <spotless.skip>false</spotless.skip>
     <spotless.check.skip>false</spotless.check.skip>
     <spotless.apply.skip>false</spotless.apply.skip>
-    <spotless.ratchetFrom>origin/master</spotless.ratchetFrom>
+    <spotless.ratchetFrom>origin/main</spotless.ratchetFrom>
     <gitHubRepo>jenkinsci/allure-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
     <jenkins.baseline>2.462</jenkins.baseline>


### PR DESCRIPTION
This updates the release automation to follow the release workflow pattern we use across the Allure team.

Releases are now handled in two separate steps. The manual release.yml workflow prepares the release, creates the release commit and tag, updates the next development version, and publishes the GitHub release. The new publish.yml workflow runs only for the published tag and handles deployment from that tagged state. This keeps release preparation separate from artifact publishing and makes the flow easier to reason about.

This PR also replaces the remaining master references with main.