### PR TITLE
Fix Allure report browsing with S3 and other remote artifact storage

### DIFF
--- a/src/main/java/org/allurereport/jenkins/AllureReportBuildAction.java
+++ b/src/main/java/org/allurereport/jenkins/AllureReportBuildAction.java
@@ -54,8 +54,6 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import static java.lang.String.format;
 
@@ -276,27 +274,26 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
 
     @SuppressWarnings("unused")
     public Object doDynamic(final StaplerRequest request, final StaplerResponse response)
-        throws IOException, InterruptedException {
+            throws IOException, InterruptedException {
 
         final FilePath runRootDir = new FilePath(run.getRootDir());
         final String reportDirName = getReportPath();
-
         final FilePath reportDirectoryUnderBuild = runRootDir.child(reportDirName);
+
+        final AllureReportArchiveSource archiveSource = AllureReportArchiveSourceFactory.forRun(run);
+        if (archiveSource.exists()) {
+            return new ArchiveReportBrowser(archiveSource, reportDirName, reportDirectoryUnderBuild.getRemote());
+        }
+        archiveSource.close();
+
         if (reportDirectoryUnderBuild.exists()) {
             return new DirectoryReportBrowser(reportDirectoryUnderBuild);
         }
 
-        final FilePath archivedZip = runRootDir.child("archive/allure-report.zip");
-        if (archivedZip.exists()) {
-            final ArchiveReportBrowser browser = new ArchiveReportBrowser(archivedZip);
-            browser.setReportPath(reportDirName);
-            return browser;
-        }
-
         response.sendError(
-            HttpServletResponse.SC_NOT_FOUND,
-            "Allure report not found. Neither directory '" + reportDirectoryUnderBuild.getRemote()
-                + "' nor archive '" + archivedZip.getRemote() + "' exists."
+                HttpServletResponse.SC_NOT_FOUND,
+                "Allure report not found. Neither archive/artifact storage nor directory '"
+                        + reportDirectoryUnderBuild.getRemote() + "' exists."
         );
         return null;
     }
@@ -458,21 +455,21 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
     }
 
     /**
-     * Serves report content from archived zip.
+     * Browser that serves report files from an {@link AllureReportArchiveSource}
+     * (local zip or remote artifact storage).
      */
     private static final class ArchiveReportBrowser implements HttpResponse {
 
-        private final FilePath archive;
+        private final AllureReportArchiveSource source;
+        private final String reportPath;
+        private final String reportDirectoryPath;
 
-        private String reportPath;
-
-        ArchiveReportBrowser(final FilePath archive) {
-            this.archive = archive;
-            this.reportPath = ALLURE_REPORT;
-        }
-
-        public void setReportPath(final String reportPath) {
+        ArchiveReportBrowser(final AllureReportArchiveSource source,
+                             final String reportPath,
+                             final String reportDirectoryPath) {
+            this.source = source;
             this.reportPath = reportPath;
+            this.reportDirectoryPath = reportDirectoryPath;
         }
 
         @Override
@@ -480,49 +477,83 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
                                      final StaplerResponse rsp,
                                      final Object node)
                 throws IOException, ServletException {
-            rsp.setHeader(HEADER_CONTENT_SECURITY_POLICY, "");
-            rsp.setHeader(HEADER_X_CONTENT_TYPE_OPTIONS, HEADER_NOSNIFF);
-            rsp.setHeader(CACHE_CONTROL, CACHE_CONTROL_NO_CACHE);
-            rsp.addHeader(CACHE_CONTROL, CACHE_CONTROL_POST_CHECK);
-            rsp.setHeader(HEADER_PRAGMA, HEADER_PRAGMA_NO_CACHE);
-            rsp.setDateHeader(HEADER_EXPIRES, 0);
-
-            final String path = initialZipPath(req, rsp);
-            if (path == null) {
-                return;
-            }
-            try (ZipFile allureReport = new ZipFile(archive.getRemote())) {
-                final ZipEntry entry = findEntry(allureReport, path);
-                if (entry != null && !entry.isDirectory()) {
-                    try (InputStream entryStream = allureReport.getInputStream(entry)) {
-                        rsp.serveFile(req, entryStream, -1L, -1L, -1L, entry.getName());
-                    }
+            try (AllureReportArchiveSource s = this.source) {
+                final AllureReportArchiveSource active = s.activeSource();
+                if (active == null) {
+                    rsp.sendError(
+                            HttpServletResponse.SC_NOT_FOUND,
+                            "Allure report not found. Checked: directory '" + reportDirectoryPath
+                                    + "', and archive/artifact storage."
+                    );
                     return;
                 }
+
+                rsp.setHeader(HEADER_CONTENT_SECURITY_POLICY, "");
+                rsp.setHeader(HEADER_X_CONTENT_TYPE_OPTIONS, HEADER_NOSNIFF);
+                rsp.setHeader(CACHE_CONTROL, CACHE_CONTROL_NO_CACHE);
+                rsp.addHeader(CACHE_CONTROL, CACHE_CONTROL_POST_CHECK);
+                rsp.setHeader(HEADER_PRAGMA, HEADER_PRAGMA_NO_CACHE);
+                rsp.setDateHeader(HEADER_EXPIRES, 0);
+
+                final String rest = normalizeRestOfPath(req, rsp);
+                if (rest == null) {
+                    return;
+                }
+
+                final String path = rest.isEmpty() ? SLASH + INDEX_HTML : rest;
+                if (!path.endsWith(SLASH) && tryServeEntry(req, rsp, active, path)) {
+                    return;
+                }
+
+                final String candidate = candidateIndexPath(path);
+                if (tryServeEntry(req, rsp, active, candidate)) {
+                    return;
+                }
+
+                rsp.sendRedirect2(baseUri(req) + INDEX_HTML + HASH_404);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                throw new IOException("Interrupted while reading archive entry", interrupted);
             }
-            rsp.sendRedirect2(baseUri(req) + INDEX_HTML + HASH_404);
         }
 
-        private String initialZipPath(final StaplerRequest req, final StaplerResponse rsp) throws IOException {
-            final String rawRest = req.getRestOfPath() == null ? "" : req.getRestOfPath();
-            final String rest = decodeAndValidatePath(rawRest, rsp);
+        private String normalizeRestOfPath(final StaplerRequest req,
+                                           final StaplerResponse rsp) throws IOException {
+            String rest = req.getRestOfPath();
             if (rest == null) {
+                rest = "";
+            }
+            if (!rest.isEmpty() && !rest.startsWith(SLASH)) {
+                rest = SLASH + rest;
+            }
+            if (rest.contains(PATH_TRAVERSAL)) {
+                rsp.sendError(HttpServletResponse.SC_BAD_REQUEST, ILLEGAL_PATH);
                 return null;
             }
-            return rest.isEmpty() ? SLASH + INDEX_HTML : rest;
+            return rest;
         }
 
-        private ZipEntry findEntry(final ZipFile zip, final String path) {
-            final ZipEntry direct = zip.getEntry(this.reportPath + path);
-            if (direct != null) {
-                return direct;
+        private boolean tryServeEntry(final StaplerRequest req,
+                                      final StaplerResponse rsp,
+                                      final AllureReportArchiveSource active,
+                                      final String path)
+                throws IOException, InterruptedException, ServletException {
+            final String entryPath = reportPath + path;
+            try (InputStream is = active.openEntry(entryPath)) {
+                rsp.serveFile(req, is, -1L, -1L, -1L, fileName(path));
+                return true;
+            } catch (NoSuchElementException ignored) {
+                return false;
             }
-            final String candidate = candidateIndexPath(path);
-            return zip.getEntry(this.reportPath + candidate);
         }
 
         private String candidateIndexPath(final String path) {
-            return path.endsWith(SLASH) ? (path + INDEX_HTML) : (path + SLASH + INDEX_HTML);
+            return path.endsWith(SLASH) ? path + INDEX_HTML : path + SLASH + INDEX_HTML;
+        }
+
+        private String fileName(final String path) {
+            final int idx = path.lastIndexOf(SLASH);
+            return idx >= 0 ? path.substring(idx + 1) : path;
         }
 
         private String baseUri(final StaplerRequest req) {
@@ -531,7 +562,6 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
             if (restOfPath.isEmpty() || !requestUri.endsWith(restOfPath)) {
                 return ensureTrailingSlash(requestUri);
             }
-
             final String base = requestUri.substring(0, requestUri.length() - restOfPath.length());
             return ensureTrailingSlash(base);
         }

--- a/src/main/java/org/allurereport/jenkins/AllureReportBuildAction.java
+++ b/src/main/java/org/allurereport/jenkins/AllureReportBuildAction.java
@@ -478,8 +478,7 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
                                      final Object node)
                 throws IOException, ServletException {
             try (AllureReportArchiveSource s = this.source) {
-                final AllureReportArchiveSource active = s.activeSource();
-                if (active == null) {
+                if (!s.exists()) {
                     rsp.sendError(
                             HttpServletResponse.SC_NOT_FOUND,
                             "Allure report not found. Checked: directory '" + reportDirectoryPath
@@ -501,12 +500,12 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
                 }
 
                 final String path = rest.isEmpty() ? SLASH + INDEX_HTML : rest;
-                if (!path.endsWith(SLASH) && tryServeEntry(req, rsp, active, path)) {
+                if (!path.endsWith(SLASH) && tryServeEntry(req, rsp, s, path)) {
                     return;
                 }
 
                 final String candidate = candidateIndexPath(path);
-                if (tryServeEntry(req, rsp, active, candidate)) {
+                if (tryServeEntry(req, rsp, s, candidate)) {
                     return;
                 }
 
@@ -523,23 +522,23 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
             if (rest == null) {
                 rest = "";
             }
+            rest = decodeAndValidatePath(rest, rsp);
+            if (rest == null) {
+                return null;
+            }
             if (!rest.isEmpty() && !rest.startsWith(SLASH)) {
                 rest = SLASH + rest;
-            }
-            if (rest.contains(PATH_TRAVERSAL)) {
-                rsp.sendError(HttpServletResponse.SC_BAD_REQUEST, ILLEGAL_PATH);
-                return null;
             }
             return rest;
         }
 
         private boolean tryServeEntry(final StaplerRequest req,
                                       final StaplerResponse rsp,
-                                      final AllureReportArchiveSource active,
+                                      final AllureReportArchiveSource sourceToRead,
                                       final String path)
                 throws IOException, InterruptedException, ServletException {
             final String entryPath = reportPath + path;
-            try (InputStream is = active.openEntry(entryPath)) {
+            try (InputStream is = sourceToRead.openEntry(entryPath)) {
                 rsp.serveFile(req, is, -1L, -1L, -1L, fileName(path));
                 return true;
             } catch (NoSuchElementException ignored) {

--- a/src/test/java/org/allurereport/jenkins/AllureReportBuildActionIT.java
+++ b/src/test/java/org/allurereport/jenkins/AllureReportBuildActionIT.java
@@ -33,7 +33,12 @@ import org.jvnet.hudson.test.JenkinsRule;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
+import static org.allurereport.jenkins.ArchivedReportTestSupport.buildArchivedReportWithEntries;
+import static org.allurereport.jenkins.ArchivedReportTestSupport.buildDirectoryReportWithEntries;
+import static org.allurereport.jenkins.ArchivedReportTestSupport.switchToRemoteArtifactManager;
 import static org.allurereport.jenkins.testdata.TestUtils.createAllurePublisher;
 import static org.allurereport.jenkins.testdata.TestUtils.getSimpleFileScm;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,7 +46,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AllureReportBuildActionIT {
 
     private static final String RESULTS_DIR = "allure-results";
-    private static final String INDEX_ENTRY = "allure-report/index.html";
+    private static final String REPORT_DIR = "allure-report";
+    private static final String INDEX_ENTRY = REPORT_DIR + "/index.html";
+    private static final String INDEX_PATH = "allure/index.html";
+    private static final String ENCODED_ASSET_ENTRY = REPORT_DIR + "/data/space file.txt";
+    private static final String ENCODED_ASSET_CONTENT = "decoded asset";
+    private static final String LEGACY_INDEX_CONTENT = "<html>legacy</html>";
 
     @ClassRule
     public static BuildWatcher buildWatcher = new BuildWatcher();
@@ -68,10 +78,10 @@ public class AllureReportBuildActionIT {
 
         final HtmlPage buildPage = webClient.getPage(build);
         assertThat(buildPage.getByXPath("//a[contains(@href, '/allure')]")).isNotEmpty();
-        assertThat(new File(build.getRootDir(), "allure-report")).doesNotExist();
+        assertThat(new File(build.getRootDir(), REPORT_DIR)).doesNotExist();
 
         final WebResponse response = webClient.loadWebResponse(
-                new WebRequest(new URL(jRule.getURL(), build.getUrl() + "allure/index.html"))
+                new WebRequest(new URL(jRule.getURL(), build.getUrl() + INDEX_PATH))
         );
 
         assertThat(response.getStatusCode()).isEqualTo(200);
@@ -91,6 +101,56 @@ public class AllureReportBuildActionIT {
         assertThat(response.getResponseHeaderValue("Content-Disposition"))
                 .contains("attachment; filename=\"index.html\"");
         assertThat(response.getContentAsString()).isEqualTo(readArchivedEntry(build, INDEX_ENTRY));
+    }
+
+    @Test
+    public void shouldServeArchivedAssetWhenRequestPathIsUrlEncoded() throws Exception {
+        final FreeStyleBuild build = buildArchivedReportWithEntries(Map.of(
+                INDEX_ENTRY, "<html/>",
+                ENCODED_ASSET_ENTRY, ENCODED_ASSET_CONTENT
+        ), jRule, REPORT_DIR);
+        final JenkinsRule.WebClient webClient = jRule.createWebClient().withJavaScriptEnabled(false);
+
+        final WebResponse response = webClient.loadWebResponse(
+                new WebRequest(new URL(jRule.getURL(), build.getUrl() + "allure/data/space%20file.txt"))
+        );
+
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getContentAsString()).isEqualTo(ENCODED_ASSET_CONTENT);
+    }
+
+    @Test
+    public void shouldServeReportFromArtifactManagerWhenLocalArchiveIsMissing() throws Exception {
+        final FreeStyleBuild build = buildSingleReportBuild();
+        final File remoteRoot = folder.newFolder();
+        switchToRemoteArtifactManager(build, remoteRoot);
+
+        final JenkinsRule.WebClient webClient = jRule.createWebClient().withJavaScriptEnabled(false);
+        final WebResponse response = webClient.loadWebResponse(
+                new WebRequest(new URL(jRule.getURL(), build.getUrl() + INDEX_PATH))
+        );
+
+        assertThat(new File(build.getArtifactsDir(), AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP))
+                .doesNotExist();
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getContentAsString()).isEqualTo(readArchivedEntry(build, INDEX_ENTRY));
+    }
+
+    @Test
+    public void shouldFallBackToLegacyDirectoryReportWhenArchiveIsMissing() throws Exception {
+        final FreeStyleBuild build = buildDirectoryReportWithEntries(Map.of(
+                "index.html", LEGACY_INDEX_CONTENT
+        ), jRule, REPORT_DIR);
+        final JenkinsRule.WebClient webClient = jRule.createWebClient().withJavaScriptEnabled(false);
+
+        final WebResponse response = webClient.loadWebResponse(
+                new WebRequest(new URL(jRule.getURL(), build.getUrl() + INDEX_PATH))
+        );
+
+        assertThat(new File(build.getArtifactsDir(), AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP))
+                .doesNotExist();
+        assertThat(response.getStatusCode()).isEqualTo(200);
+        assertThat(response.getContentAsString()).isEqualTo(LEGACY_INDEX_CONTENT);
     }
 
     @Test
@@ -138,7 +198,7 @@ public class AllureReportBuildActionIT {
     private String readArchivedEntry(final FreeStyleBuild build, final String entryPath) throws Exception {
         try (AllureReportArchiveSource source = AllureReportArchiveSourceFactory.forRun(build);
              InputStream inputStream = source.openEntry(entryPath)) {
-            return new String(inputStream.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+            return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
         }
     }
 }

--- a/src/test/java/org/allurereport/jenkins/ArchivedReportTestSupport.java
+++ b/src/test/java/org/allurereport/jenkins/ArchivedReportTestSupport.java
@@ -1,0 +1,145 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins;
+
+import hudson.Util;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Run;
+import jenkins.model.ArtifactManager;
+import jenkins.util.VirtualFile;
+import org.allurereport.jenkins.utils.AllureReportArchiveSourceFactory;
+import org.allurereport.jenkins.utils.BuildSummary;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.File;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+final class ArchivedReportTestSupport {
+
+    private ArchivedReportTestSupport() {
+    }
+
+    static void switchToRemoteArtifactManager(final FreeStyleBuild build, final File remoteRoot) throws Exception {
+        final File localZip = new File(build.getArtifactsDir(), AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP);
+        final File remoteZip = new File(remoteRoot, AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP);
+        Files.createDirectories(remoteRoot.toPath());
+        Files.copy(localZip.toPath(), remoteZip.toPath());
+        Files.delete(localZip.toPath());
+
+        final Field artifactManager = Run.class.getDeclaredField("artifactManager");
+        artifactManager.setAccessible(true);
+        final ArtifactManager manager = new StaticArtifactManager(remoteRoot);
+        manager.onLoad(build);
+        artifactManager.set(build, manager);
+    }
+
+    static FreeStyleBuild buildArchivedReportWithEntries(final Map<String, String> entries,
+                                                         final JenkinsRule jRule,
+                                                         final String reportPath) throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+
+        writeArchive(build, entries);
+
+        final AllureReportBuildAction action = new AllureReportBuildAction(new BuildSummary(), false);
+        action.setReportPath(reportPath);
+        build.addAction(action);
+        build.save();
+        return build;
+    }
+
+    static FreeStyleBuild buildDirectoryReportWithEntries(final Map<String, String> entries,
+                                                          final JenkinsRule jRule,
+                                                          final String reportPath) throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+
+        writeDirectoryReport(build, reportPath, entries);
+
+        final AllureReportBuildAction action = new AllureReportBuildAction(new BuildSummary(), false);
+        action.setReportPath(reportPath);
+        build.addAction(action);
+        build.save();
+        return build;
+    }
+
+    private static void writeArchive(final FreeStyleBuild build, final Map<String, String> entries) throws Exception {
+        final File archive = new File(build.getArtifactsDir(), AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP);
+        Files.createDirectories(archive.toPath().getParent());
+        try (OutputStream fileOut = Files.newOutputStream(archive.toPath());
+             ZipOutputStream zipOut = new ZipOutputStream(fileOut)) {
+            for (Map.Entry<String, String> entry : entries.entrySet()) {
+                zipOut.putNextEntry(new ZipEntry(entry.getKey()));
+                zipOut.write(entry.getValue().getBytes(StandardCharsets.UTF_8));
+                zipOut.closeEntry();
+            }
+        }
+    }
+
+    private static void writeDirectoryReport(final FreeStyleBuild build,
+                                             final String reportPath,
+                                             final Map<String, String> entries) throws Exception {
+        final File reportDir = new File(build.getRootDir(), reportPath);
+        Files.createDirectories(reportDir.toPath());
+        for (Map.Entry<String, String> entry : entries.entrySet()) {
+            final File target = new File(reportDir, entry.getKey());
+            final File parent = target.getParentFile();
+            if (parent != null) {
+                Files.createDirectories(parent.toPath());
+            }
+            Files.writeString(target.toPath(), entry.getValue(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static final class StaticArtifactManager extends ArtifactManager {
+
+        private final File remoteRoot;
+
+        StaticArtifactManager(final File remoteRoot) {
+            this.remoteRoot = remoteRoot;
+        }
+
+        @Override
+        public void onLoad(final Run<?, ?> run) {
+        }
+
+        @Override
+        public void archive(final hudson.FilePath workspace,
+                            final hudson.Launcher launcher,
+                            final hudson.model.BuildListener listener,
+                            final Map<String, String> artifacts) {
+            throw new UnsupportedOperationException("Not used in tests");
+        }
+
+        @Override
+        public boolean delete() throws java.io.IOException, InterruptedException {
+            Util.deleteRecursive(remoteRoot);
+            return true;
+        }
+
+        @Override
+        public VirtualFile root() {
+            return VirtualFile.forFile(remoteRoot);
+        }
+    }
+}


### PR DESCRIPTION
fixes #445 

<!-- Please describe your pull request here. -->
fix based on two commits
https://github.com/jenkinsci/allure-plugin/commit/c8e9d3649fd76fd1a376cbd920bb77ffca9f68a3
https://github.com/jenkinsci/allure-plugin/commit/dcbfc95ea10c3e92a9fdab902fe1e7ebd5c8144d

i copied realization `doDynamic` and `ArchiveReportBrowser` from dcbfc95ea10c3e92a9fdab902fe1e7ebd5c8144d into `AllureReportBuildAction`. and fix checkstyle and pmd violations.

### Testing done

locally jenkins with s3 cloud artifact works correct(release version still make error page)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
