### PR TITLE
Fix broken Allure history links

### DIFF
--- a/src/main/java/org/allurereport/jenkins/AllureReportPublisher.java
+++ b/src/main/java/org/allurereport/jenkins/AllureReportPublisher.java
@@ -804,8 +804,9 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
 
         final String rootUrl = StringUtils.trimToNull(Jenkins.get().getRootUrl());
         final String buildUrl = DisplayURLProvider.get().getRunURL(run);
-        final String reportUrl = buildUrl.endsWith(SLASH) ? (buildUrl + ALLURE_PREFIX)
-                : (buildUrl + SLASH + ALLURE_PREFIX);
+        final String classicBuildUrl = rootUrl == null ? run.getUrl() : rootUrl + run.getUrl();
+        final String reportUrl = classicBuildUrl.endsWith(SLASH) ? (classicBuildUrl + ALLURE_PREFIX)
+                : (classicBuildUrl + SLASH + ALLURE_PREFIX);
 
         final String buildId = run.getId();
 

--- a/src/test/java/org/allurereport/jenkins/AllureReportPublisherIT.java
+++ b/src/test/java/org/allurereport/jenkins/AllureReportPublisherIT.java
@@ -24,6 +24,7 @@ import org.allurereport.jenkins.config.ResultPolicy;
 import org.allurereport.jenkins.testdata.TestUtils;
 import org.allurereport.jenkins.utils.AllureReportArchiveSource;
 import org.allurereport.jenkins.utils.AllureReportArchiveSourceFactory;
+import org.jenkinsci.plugins.displayurlapi.DisplayURLProvider;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -32,7 +33,9 @@ import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.regex.Pattern;
 
 import static org.allurereport.jenkins.testdata.TestUtils.createAllurePublisher;
 import static org.allurereport.jenkins.testdata.TestUtils.getSimpleFileScm;
@@ -43,6 +46,11 @@ public class AllureReportPublisherIT {
     private static final String RESULTS_DIR = "allure-results";
     private static final String SAMPLE_PASSED = "sample-testsuite.xml";
     private static final String SAMPLE_FAILED = "sample-testsuite-with-failed.xml";
+    private static final String HISTORY_ENTRY = "allure-report/history/history.json";
+    private static final String EXECUTORS_ENTRY = "allure-report/widgets/executors.json";
+    private static final String KEY_ITEMS = "items";
+    private static final String KEY_REPORT_URL = "reportUrl";
+    private static final String DISPLAY_REDIRECT = "display/redirect";
 
     @ClassRule
     public static BuildWatcher buildWatcher = new BuildWatcher();
@@ -117,22 +125,66 @@ public class AllureReportPublisherIT {
         assertThat(secondHistoryItems).isGreaterThan(firstHistoryItems);
     }
 
+    @Test
+    public void shouldUseDisplayUrlForBuildLinksAndClassicUrlForReportLinks() throws Exception {
+        final FreeStyleProject project = createProject(SAMPLE_PASSED);
+        project.getPublishersList().add(createAllurePublisher(jdk, commandline, RESULTS_DIR));
+
+        jRule.buildAndAssertSuccess(project);
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+
+        final JsonNode executors = archivedJson(build, EXECUTORS_ENTRY);
+        final JsonNode executor = executors.get(0);
+
+        assertThat(executor.path("buildUrl").asText()).isEqualTo(DisplayURLProvider.get().getRunURL(build));
+        assertThat(executor.path(KEY_REPORT_URL).asText()).isEqualTo(classicReportUrl(build));
+        assertThat(executor.path(KEY_REPORT_URL).asText()).doesNotContain(DISPLAY_REDIRECT);
+
+        final JsonNode history = archivedJson(build, HISTORY_ENTRY);
+        final List<String> reportUrls = new ArrayList<>();
+        for (JsonNode testHistory : history) {
+            for (JsonNode item : testHistory.path(KEY_ITEMS)) {
+                reportUrls.add(item.path(KEY_REPORT_URL).asText());
+            }
+        }
+
+        final String reportUrlPattern = "^" + Pattern.quote(classicProjectUrl(project))
+                + "\\d+/allure/#testresult/.+$";
+        assertThat(reportUrls).isNotEmpty();
+        assertThat(reportUrls).allSatisfy(reportUrl -> {
+            assertThat(reportUrl).matches(reportUrlPattern);
+            assertThat(reportUrl).doesNotContain(DISPLAY_REDIRECT);
+        });
+    }
+
     private FreeStyleProject createProject(final String resourceName) throws Exception {
         final FreeStyleProject project = jRule.createFreeStyleProject();
         project.setScm(getSimpleFileScm(resourceName, RESULTS_DIR + "/sample-testsuite.xml"));
         return project;
     }
 
-    private int historyItems(final FreeStyleBuild build) throws Exception {
+    private JsonNode archivedJson(final FreeStyleBuild build, final String entryName) throws Exception {
         final ObjectMapper mapper = new ObjectMapper();
         try (AllureReportArchiveSource source = AllureReportArchiveSourceFactory.forRun(build);
-             InputStream inputStream = source.openEntry("allure-report/history/history.json")) {
-            final JsonNode root = mapper.readTree(inputStream);
-            int items = 0;
-            for (JsonNode testHistory : root) {
-                items += testHistory.path("items").size();
-            }
-            return items;
+             InputStream inputStream = source.openEntry(entryName)) {
+            return mapper.readTree(inputStream);
         }
+    }
+
+    private String classicProjectUrl(final FreeStyleProject project) {
+        return jRule.jenkins.getRootUrl() + project.getUrl();
+    }
+
+    private String classicReportUrl(final FreeStyleBuild build) {
+        return jRule.jenkins.getRootUrl() + build.getUrl() + "allure";
+    }
+
+    private int historyItems(final FreeStyleBuild build) throws Exception {
+        final JsonNode root = archivedJson(build, HISTORY_ENTRY);
+        int items = 0;
+        for (JsonNode testHistory : root) {
+            items += testHistory.path(KEY_ITEMS).size();
+        }
+        return items;
     }
 }


### PR DESCRIPTION
This fixes a regression introduced in `2.35.0` where links from a test's History tab could open the Jenkins pipeline page instead of the older Allure test result.

When Jenkins returns build URLs through `display/redirect` (for example with Blue Ocean installed), that URL works as a build landing page but not as a stable base for deep links inside an archived Allure report. As a result, clicking a previous result from History could take users out of Allure entirely.

With this change:

- build links still follow the Jenkins UI preference
- Allure report links use the stable classic build URL
- History links open the previous Allure test result again instead of redirecting to the pipeline view

This keeps Jenkins navigation flexible while restoring the expected behavior inside Allure reports.

Fixes #449 