### PR TITLE
Add Jenkins compatibility coverage and Allure-powered CI reports

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,7 @@ jobs:
         package-manager-cache: false
     - name: Download Allure dumps
       uses: actions/download-artifact@v4
+      continue-on-error: true
       with:
         pattern: allure-results-*
         path: ./
@@ -73,6 +74,7 @@ jobs:
     - name: Generate Allure report
       run: >-
         npx --yes allure@3 generate
+        --config ./allurerc.mjs
         --dump="allure-results-*.zip"
         --output=./build/allure-report
     - name: Upload Allure report

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - '*'
@@ -10,7 +14,11 @@ on:
 
 jobs:
   build:
+    name: Build and test
     runs-on: ubuntu-latest
+    env:
+      ALLURE_DUMP_NAME: allure-results-build
+      ALLURE_ENVIRONMENT: ubuntu-jdk-11
     steps:
     - uses: actions/checkout@v6
       with:
@@ -20,5 +28,63 @@ jobs:
         distribution: temurin
         java-version: 11
         cache: 'maven'
-    - name: "Build"
-      run: ./mvnw package
+    - uses: actions/setup-node@v7
+      with:
+        node-version: '24'
+        package-manager-cache: false
+    - name: Build and test with Allure
+      run: >-
+        npx --yes allure@3 run
+        --environment="${ALLURE_ENVIRONMENT}"
+        --dump="${ALLURE_DUMP_NAME}"
+        --results-dir=target/allure-results
+        -- ./mvnw -B -ntp verify
+    - name: Upload Allure dump
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ env.ALLURE_DUMP_NAME }}
+        path: ./${{ env.ALLURE_DUMP_NAME }}.zip
+        if-no-files-found: error
+
+  report:
+    name: Build report
+    runs-on: ubuntu-latest
+    needs: build
+    if: always()
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+    env:
+      ALLURE_SERVICE_TOKEN: ${{ secrets.ALLURE_SERVICE_TOKEN }}
+    steps:
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v7
+      with:
+        node-version: '24'
+        package-manager-cache: false
+    - name: Download Allure dumps
+      uses: actions/download-artifact@v4
+      with:
+        pattern: allure-results-*
+        path: ./
+        merge-multiple: true
+    - name: Generate Allure report
+      run: >-
+        npx --yes allure@3 generate
+        --dump="allure-results-*.zip"
+        --output=./build/allure-report
+    - name: Upload Allure report
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: allure-report
+        path: ./build/allure-report
+        if-no-files-found: warn
+    - name: Post Allure summary
+      if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+      uses: allure-framework/allure-action@v0
+      with:
+        report-directory: ./build/allure-report
+        github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -1,0 +1,88 @@
+name: Compatibility Smoke
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      jenkins_version:
+        description: Jenkins Docker tag or core version to test
+        required: true
+        default: '2.462.1'
+        type: string
+
+jobs:
+  build-plugin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      - name: Build plugin artifact
+        run: ./mvnw -B -ntp -DskipTests clean package
+      - name: Upload plugin hpi
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-hpi
+          path: target/*.hpi
+          if-no-files-found: error
+
+  compat:
+    runs-on: ubuntu-latest
+    needs: build-plugin
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      - name: Resolve Jenkins version
+        id: resolve-version
+        run: |
+          echo "jenkins_version=${{ github.event.inputs.jenkins_version }}" >> "$GITHUB_OUTPUT"
+      - name: Download plugin hpi
+        uses: actions/download-artifact@v4
+        with:
+          name: plugin-hpi
+          path: target
+      - name: Run Jenkins compatibility smoke
+        env:
+          JENKINS_VERSION: ${{ steps.resolve-version.outputs.jenkins_version }}
+          COMPAT_ARTIFACT_ROOT: ${{ github.workspace }}/compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}
+        run: |
+          echo "Running Jenkins compatibility smoke for version: $JENKINS_VERSION"
+          ./mvnw -B -e -ntp -f compat/jenkins-smoke/pom.xml \
+            -Dcompat.rootDir="${{ github.workspace }}" \
+            -Dcompat.version="$JENKINS_VERSION" \
+            -Dcompat.artifactRoot="$COMPAT_ARTIFACT_ROOT" \
+            compile exec:java
+      - name: Print compatibility artifact index
+        if: always()
+        run: |
+          if [[ -d "compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}" ]]; then
+            find "compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}" -maxdepth 2 -type f | sort
+          else
+            echo "No compatibility artifacts directory found."
+          fi
+      - name: Upload compatibility artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compat-${{ steps.resolve-version.outputs.jenkins_version }}
+          path: compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}
+          if-no-files-found: warn
+      - name: Append workflow summary
+        if: always()
+        run: |
+          echo "## Jenkins ${{ steps.resolve-version.outputs.jenkins_version }}" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -f "compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}/summary.md" ]]; then
+            cat "compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- Compatibility smoke did not complete successfully." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -103,7 +103,7 @@ jobs:
             echo "- Allure 3 dump: \`${DUMP_PATH}\` (${DUMP_SIZE})" >> "$GITHUB_STEP_SUMMARY"
             echo "- Workflow artifact: \`compat-${JENKINS_VERSION}-allure3-dump\`" >> "$GITHUB_STEP_SUMMARY"
             echo "- Global evidence: Jenkins controller log, shared Jenkins setup inputs, and Maven process logs" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Generate a report: \`npx --yes allure@3 generate --dump=${DUMP_PATH}\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Generate a report: \`npx --yes allure@3 generate --config ./allurerc.mjs --dump=${DUMP_PATH}\`" >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- Compatibility smoke did not produce an Allure 3 dump." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -4,6 +4,17 @@ permissions:
   contents: read
 
 on:
+  pull_request:
+    branches:
+      - '*'
+    paths:
+      - '.github/workflows/compat.yml'
+      - '.mvn/**'
+      - 'compat/jenkins-smoke/**'
+      - 'mvnw'
+      - 'mvnw.cmd'
+      - 'pom.xml'
+      - 'src/**'
   workflow_dispatch:
     inputs:
       jenkins_version:
@@ -11,6 +22,10 @@ on:
         required: true
         default: '2.462.1'
         type: string
+
+concurrency:
+  group: compat-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build-plugin:
@@ -35,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-plugin
     timeout-minutes: 45
+    env:
+      JENKINS_VERSION: ${{ inputs.jenkins_version || '2.462.1' }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -42,10 +59,10 @@ jobs:
           distribution: temurin
           java-version: '17'
           cache: maven
-      - name: Resolve Jenkins version
-        id: resolve-version
-        run: |
-          echo "jenkins_version=${{ github.event.inputs.jenkins_version }}" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          package-manager-cache: false
       - name: Download plugin hpi
         uses: actions/download-artifact@v4
         with:
@@ -53,39 +70,38 @@ jobs:
           path: target
       - name: Run Jenkins compatibility smoke
         env:
-          JENKINS_VERSION: ${{ steps.resolve-version.outputs.jenkins_version }}
-          COMPAT_ARTIFACT_ROOT: ${{ github.workspace }}/compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}
+          COMPAT_ARTIFACT_ROOT: ${{ github.workspace }}/compat-artifacts/${{ env.JENKINS_VERSION }}
+          ALLURE_DUMP: ${{ github.workspace }}/allure-dumps/compat-${{ env.JENKINS_VERSION }}
         run: |
           echo "Running Jenkins compatibility smoke for version: $JENKINS_VERSION"
-          ./mvnw -B -e -ntp -f compat/jenkins-smoke/pom.xml \
-            -Dcompat.rootDir="${{ github.workspace }}" \
-            -Dcompat.version="$JENKINS_VERSION" \
-            -Dcompat.artifactRoot="$COMPAT_ARTIFACT_ROOT" \
-            test
-      - name: Print compatibility artifact index
-        if: always()
-        run: |
-          if [[ -d "compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}" ]]; then
-            find "compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}" -maxdepth 2 -type f | sort
-          else
-            echo "No compatibility artifacts directory found."
-          fi
-      - name: Upload compatibility artifacts
+          mkdir -p "${ALLURE_DUMP%/*}"
+          ALLURE_ENVIRONMENT_ID="jenkins-${JENKINS_VERSION//[^a-zA-Z0-9_-]/-}"
+          npx --yes allure@3 run \
+            --dump="$ALLURE_DUMP" \
+            --environment="$ALLURE_ENVIRONMENT_ID" \
+            -- ./mvnw -B -e -ntp -f compat/jenkins-smoke/pom.xml \
+              -Dcompat.rootDir="${{ github.workspace }}" \
+              -Dcompat.version="$JENKINS_VERSION" \
+              -Dcompat.artifactRoot="$COMPAT_ARTIFACT_ROOT" \
+              test
+      - name: Upload Allure 3 dump
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: compat-${{ steps.resolve-version.outputs.jenkins_version }}
-          path: compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}
-          if-no-files-found: warn
+          name: compat-${{ env.JENKINS_VERSION }}-allure3-dump
+          path: allure-dumps/compat-${{ env.JENKINS_VERSION }}.zip
+          if-no-files-found: error
       - name: Append workflow summary
         if: always()
         run: |
-          echo "## Jenkins ${{ steps.resolve-version.outputs.jenkins_version }}" >> "$GITHUB_STEP_SUMMARY"
-          if [[ -d "compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}/allure-results" ]]; then
-            RESULT_FILES=$(find "compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}/allure-results" -name '*-result.json' | wc -l | tr -d ' ')
-            echo "- Allure results: \`compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}/allure-results\`" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Surefire reports: \`compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}/surefire-reports\`" >> "$GITHUB_STEP_SUMMARY"
-            echo "- Allure result files: ${RESULT_FILES}" >> "$GITHUB_STEP_SUMMARY"
+          DUMP_PATH="allure-dumps/compat-${JENKINS_VERSION}.zip"
+          echo "## Jenkins ${JENKINS_VERSION}" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -f "$DUMP_PATH" ]]; then
+            DUMP_SIZE=$(du -h "$DUMP_PATH" | cut -f1)
+            echo "- Allure 3 dump: \`${DUMP_PATH}\` (${DUMP_SIZE})" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Workflow artifact: \`compat-${JENKINS_VERSION}-allure3-dump\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Global evidence: Jenkins controller log, shared Jenkins setup inputs, and Maven process logs" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Generate a report: \`npx --yes allure@3 generate --dump=${DUMP_PATH}\`" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- Compatibility smoke did not produce Allure results." >> "$GITHUB_STEP_SUMMARY"
+            echo "- Compatibility smoke did not produce an Allure 3 dump." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -61,7 +61,7 @@ jobs:
             -Dcompat.rootDir="${{ github.workspace }}" \
             -Dcompat.version="$JENKINS_VERSION" \
             -Dcompat.artifactRoot="$COMPAT_ARTIFACT_ROOT" \
-            compile exec:java
+            test
       - name: Print compatibility artifact index
         if: always()
         run: |
@@ -81,8 +81,11 @@ jobs:
         if: always()
         run: |
           echo "## Jenkins ${{ steps.resolve-version.outputs.jenkins_version }}" >> "$GITHUB_STEP_SUMMARY"
-          if [[ -f "compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}/summary.md" ]]; then
-            cat "compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -d "compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}/allure-results" ]]; then
+            RESULT_FILES=$(find "compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}/allure-results" -name '*-result.json' | wc -l | tr -d ' ')
+            echo "- Allure results: \`compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}/allure-results\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Surefire reports: \`compat-artifacts/${{ steps.resolve-version.outputs.jenkins_version }}/surefire-reports\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Allure result files: ${RESULT_FILES}" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- Compatibility smoke did not complete successfully." >> "$GITHUB_STEP_SUMMARY"
+            echo "- Compatibility smoke did not produce Allure results." >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: actions/setup-java@v5
         with:
           distribution: temurin

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ build
 
 # Work
 work
+compat-artifacts
 
 # Mac OS
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build
 # Work
 work
 compat-artifacts
+allure-dumps
 
 # Mac OS
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Project Guide
+
+Use [Allure Agent Mode](docs/allure-agent-mode.md) for all test-related work in this repository.
+
+A test run is an instrument, not a pass/fail to scrape. Running tests through `allure agent` turns them into a reviewable account of what actually happened, plus automated findings about the tests themselves. State what the run should confirm with `--goal`; the report carries the goal and evidence so an agent or human can validate it.
+
+- Run regular result-informing tests as `npx --yes allure@3 agent --results-dir target/allure-results --goal "<what this run should confirm>" -- <test command>`, then read the generated `AGENTS.md`, `index.md`, findings, and per-test evidence. Use the compatibility result path documented in the guide for compatibility tests.
+- On failure, inspect the exact failures and evidence before editing. Rerun only failed or unsuccessful tests through agent mode when supported. For CI failures, inspect the downloaded `allure-results-*` dump instead of reproducing locally.
+- Use the relevant test under agent mode as a debugging instrument instead of replacing it with an ad-hoc script.
+- Before writing or materially changing a test, invoke `$allure-agent-mode` and read its test-design rules. If the skill is unavailable, follow [docs/allure-agent-mode.md](docs/allure-agent-mode.md).
+
+The console summary is only the entry point. Do not reduce a result-informing run to `tail`, `grep`, `head`, or `/dev/null`; the agent output is the signal.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,12 @@
+# Project Guide
+
+Use [Allure Agent Mode](docs/allure-agent-mode.md) for all test-related work in this repository.
+
+A test run is an instrument, not a pass/fail to scrape. Running tests through `allure agent` turns them into a reviewable account of what actually happened, plus automated findings about the tests themselves. State what the run should confirm with `--goal`; the report carries the goal and evidence so an agent or human can validate it.
+
+- Run regular result-informing tests as `npx --yes allure@3 agent --results-dir target/allure-results --goal "<what this run should confirm>" -- <test command>`, then read the generated `AGENTS.md`, `index.md`, findings, and per-test evidence. Use the compatibility result path documented in the guide for compatibility tests.
+- On failure, inspect the exact failures and evidence before editing. Rerun only failed or unsuccessful tests through agent mode when supported. For CI failures, inspect the downloaded `allure-results-*` dump instead of reproducing locally.
+- Use the relevant test under agent mode as a debugging instrument instead of replacing it with an ad-hoc script.
+- Before writing or materially changing a test, invoke `$allure-agent-mode` and read its test-design rules. If the skill is unavailable, follow [docs/allure-agent-mode.md](docs/allure-agent-mode.md).
+
+The console summary is only the entry point. Do not reduce a result-informing run to `tail`, `grep`, `head`, or `/dev/null`; the agent output is the signal.

--- a/allurerc.mjs
+++ b/allurerc.mjs
@@ -1,0 +1,21 @@
+const { ALLURE_SERVICE_TOKEN } = process.env;
+
+const allureService = ALLURE_SERVICE_TOKEN
+    ? {
+        accessToken: ALLURE_SERVICE_TOKEN,
+    }
+    : undefined;
+
+export default {
+    name: "Allure Jenkins Plugin",
+    output: "./build/allure-report",
+    plugins: {
+        awesome: {
+            options: {
+                groupBy: ["module", "parentSuite", "suite", "subSuite"],
+                publish: true,
+            },
+        },
+    },
+    ...(allureService ? { allureService } : {}),
+};

--- a/compat/README.md
+++ b/compat/README.md
@@ -1,0 +1,27 @@
+# Compatibility Harness
+
+This directory contains the Jenkins compatibility smoke runner used by the manual GitHub Actions workflow.
+
+## What It Covers
+
+The runner starts a real Jenkins controller in Docker with Testcontainers, installs the plugin under test, configures Allure CLI, and verifies these flows:
+
+- Freestyle report generation
+- Pipeline step execution
+- Matrix build aggregation
+
+Artifacts such as Jenkins logs, console output, report HTML, and a markdown summary are written to `compat-artifacts/`.
+
+## Local Dry Run
+
+You need Docker available locally. Build the plugin first so the runner can pick up the generated `.hpi` from `target/`.
+
+```bash
+./mvnw -DskipTests clean package
+./mvnw -q -f compat/jenkins-smoke/pom.xml \
+  -Dcompat.rootDir="$(pwd)" \
+  -Dcompat.version=2.462.1 \
+  exec:java
+```
+
+By default, a bare Jenkins version such as `2.462.1` is normalized to the Docker image tag `2.462.1-lts-jdk17`. If you want to test an exact Docker tag, pass that tag directly via `-Dcompat.version=...`.

--- a/compat/README.md
+++ b/compat/README.md
@@ -1,16 +1,16 @@
 # Compatibility Harness
 
-This directory contains the Jenkins compatibility smoke runner used by the manual GitHub Actions workflow.
+This directory contains the Jenkins compatibility smoke tests used by the manual GitHub Actions workflow.
 
 ## What It Covers
 
-The runner starts a real Jenkins controller in Docker with Testcontainers, installs the plugin under test, configures Allure CLI, and verifies these flows:
+The suite starts a real Jenkins controller in Docker with Testcontainers, installs the plugin under test, configures Allure CLI, and verifies these flows:
 
 - Freestyle report generation
 - Pipeline step execution
 - Matrix build aggregation
 
-Artifacts such as Jenkins logs, console output, report HTML, and a markdown summary are written to `compat-artifacts/`.
+Artifacts such as Allure results, Surefire reports, Jenkins logs, console output, and report HTML are written to `compat-artifacts/`.
 
 ## Local Dry Run
 
@@ -21,7 +21,9 @@ You need Docker available locally. Build the plugin first so the runner can pick
 ./mvnw -q -f compat/jenkins-smoke/pom.xml \
   -Dcompat.rootDir="$(pwd)" \
   -Dcompat.version=2.462.1 \
-  exec:java
+  test
 ```
 
 By default, a bare Jenkins version such as `2.462.1` is normalized to the Docker image tag `2.462.1-lts-jdk17`. If you want to test an exact Docker tag, pass that tag directly via `-Dcompat.version=...`.
+
+The main test output lives in `compat-artifacts/<version>/allure-results`, which can be rendered with standard Allure tooling or uploaded as a workflow artifact.

--- a/compat/README.md
+++ b/compat/README.md
@@ -30,7 +30,7 @@ You need Docker available locally. Build the plugin first so the runner can pick
 
 By default, a bare Jenkins version such as `2.462.1` is normalized to the Docker image tag `2.462.1-lts-jdk17`. If you want to test an exact Docker tag, pass that tag directly via `-Dcompat.version=...`.
 
-The main local test output lives in `compat-artifacts/<version>/allure-results`. To reproduce the CI artifact locally, run the suite through the pinned Allure 3 CLI (Node.js and npm are required):
+The main local test output lives in `compat-artifacts/<version>/allure-results`. To reproduce the CI artifact locally, run the suite through the latest Allure 3 CLI from npm (Node.js and npm are required):
 
 ```bash
 export COMPAT_ARTIFACT_ROOT="$(pwd)/compat-artifacts/2.462.1"
@@ -49,5 +49,6 @@ This creates `allure-dumps/compat-2.462.1.zip`. Generate a report from a downloa
 
 ```bash
 npx --yes allure@3 generate \
+  --config ./allurerc.mjs \
   --dump=allure-dumps/compat-2.462.1.zip
 ```

--- a/compat/README.md
+++ b/compat/README.md
@@ -1,6 +1,6 @@
 # Compatibility Harness
 
-This directory contains the Jenkins compatibility smoke tests used by the manual GitHub Actions workflow.
+This directory contains the Jenkins compatibility smoke tests used by the GitHub Actions workflow.
 
 ## What It Covers
 
@@ -10,7 +10,11 @@ The suite starts a real Jenkins controller in Docker with Testcontainers, instal
 - Pipeline step execution
 - Matrix build aggregation
 
-Artifacts such as Allure results, Surefire reports, Jenkins logs, console output, and report HTML are written to `compat-artifacts/`.
+The harness stages Allure results, Surefire reports, Jenkins logs, console output, and report HTML under `compat-artifacts/` while it runs. GitHub Actions wraps the suite with Allure 3 and uploads a single `compat-<version>.zip` dump instead of that raw directory. The dump preserves the Allure results and their evidence attachments.
+
+Shared diagnostics are stored as global attachments: the Jenkins controller log, Jenkins initialization and setup scripts, the plugin list, and Maven stdout and stderr. Job-specific Groovy checks, JSON responses, console logs, and report pages remain attached to the test that produced them. Surefire reports stay in the local staging directory and are not duplicated in the dump.
+
+Pull requests run the suite against Jenkins `2.462.1` when plugin, build, workflow, or compatibility-harness files change. A newer commit on the same pull request cancels the superseded run. Use the manual workflow input to test an additional Jenkins version or exact Docker tag.
 
 ## Local Dry Run
 
@@ -26,4 +30,24 @@ You need Docker available locally. Build the plugin first so the runner can pick
 
 By default, a bare Jenkins version such as `2.462.1` is normalized to the Docker image tag `2.462.1-lts-jdk17`. If you want to test an exact Docker tag, pass that tag directly via `-Dcompat.version=...`.
 
-The main test output lives in `compat-artifacts/<version>/allure-results`, which can be rendered with standard Allure tooling or uploaded as a workflow artifact.
+The main local test output lives in `compat-artifacts/<version>/allure-results`. To reproduce the CI artifact locally, run the suite through the pinned Allure 3 CLI (Node.js and npm are required):
+
+```bash
+export COMPAT_ARTIFACT_ROOT="$(pwd)/compat-artifacts/2.462.1"
+mkdir -p allure-dumps
+npx --yes allure@3 run \
+  --dump=allure-dumps/compat-2.462.1 \
+  --environment=jenkins-2-462-1 \
+  -- ./mvnw -B -e -ntp -f compat/jenkins-smoke/pom.xml \
+    -Dcompat.rootDir="$(pwd)" \
+    -Dcompat.version=2.462.1 \
+    -Dcompat.artifactRoot="$COMPAT_ARTIFACT_ROOT" \
+    test
+```
+
+This creates `allure-dumps/compat-2.462.1.zip`. Generate a report from a downloaded dump with:
+
+```bash
+npx --yes allure@3 generate \
+  --dump=allure-dumps/compat-2.462.1.zip
+```

--- a/compat/jenkins-smoke/pom.xml
+++ b/compat/jenkins-smoke/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.allurereport.jenkins.compat</groupId>
+    <artifactId>allure-jenkins-compat-runner</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <compat.version>2.462.1</compat.version>
+        <jackson.version>2.18.2</jackson.version>
+        <slf4j.version>2.0.16</slf4j.version>
+        <testcontainers.version>1.20.6</testcontainers.version>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <exec.mainClass>org.allurereport.jenkins.compat.JenkinsCompatibilitySmokeRunner</exec.mainClass>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>${testcontainers.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <mainClass>${exec.mainClass}</mainClass>
+                    <cleanupDaemonThreads>false</cleanupDaemonThreads>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <repositories>
+        <repository>
+            <id>maven-central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+        </repository>
+    </repositories>
+</project>

--- a/compat/jenkins-smoke/pom.xml
+++ b/compat/jenkins-smoke/pom.xml
@@ -10,30 +10,55 @@
     <packaging>jar</packaging>
 
     <properties>
+        <allure.junit5.version>2.29.1</allure.junit5.version>
+        <compat.rootDir>${project.basedir}/../..</compat.rootDir>
         <compat.version>2.462.1</compat.version>
+        <compat.artifactRoot>${compat.rootDir}/compat-artifacts/${compat.version}</compat.artifactRoot>
         <jackson.version>2.18.2</jackson.version>
+        <junit.jupiter.version>5.11.4</junit.jupiter.version>
+        <maven.surefire-plugin.version>3.5.3</maven.surefire-plugin.version>
         <slf4j.version>2.0.16</slf4j.version>
-        <testcontainers.version>1.20.6</testcontainers.version>
+        <testcontainers.version>1.21.4</testcontainers.version>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <exec.mainClass>org.allurereport.jenkins.compat.JenkinsCompatibilitySmokeRunner</exec.mainClass>
     </properties>
 
     <dependencies>
         <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-junit5</artifactId>
+            <version>${allure.junit5.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${testcontainers.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${testcontainers.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -48,12 +73,20 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.5.0</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire-plugin.version}</version>
                 <configuration>
-                    <mainClass>${exec.mainClass}</mainClass>
-                    <cleanupDaemonThreads>false</cleanupDaemonThreads>
+                    <failIfNoTests>true</failIfNoTests>
+                    <reportsDirectory>${compat.artifactRoot}/surefire-reports</reportsDirectory>
+                    <trimStackTrace>false</trimStackTrace>
+                    <redirectTestOutputToFile>false</redirectTestOutputToFile>
+                    <systemPropertyVariables>
+                        <allure.results.directory>${compat.artifactRoot}/allure-results</allure.results.directory>
+                        <compat.artifactRoot>${compat.artifactRoot}</compat.artifactRoot>
+                        <compat.rootDir>${compat.rootDir}</compat.rootDir>
+                        <compat.version>${compat.version}</compat.version>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
         </plugins>

--- a/compat/jenkins-smoke/src/main/java/org/allurereport/jenkins/compat/JenkinsCompatibilitySmokeRunner.java
+++ b/compat/jenkins-smoke/src/main/java/org/allurereport/jenkins/compat/JenkinsCompatibilitySmokeRunner.java
@@ -1,0 +1,780 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.compat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * Starts a real Jenkins in Docker, installs the plugin under test, configures smoke jobs,
+ * and verifies the main plugin flows against a requested Jenkins version.
+ */
+public final class JenkinsCompatibilitySmokeRunner {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final Pattern ALLURE_CLI_VERSION_PATTERN =
+            Pattern.compile("<allureCommandline\\.version>([^<]+)</allureCommandline\\.version>");
+
+    private static final String SMOKE_DATA_DIR = "/usr/share/jenkins/ref/smoke-data";
+    private static final String PASSED_SAMPLE_RESOURCE = "src/test/resources/sample-testsuite.xml";
+    private static final String FAILED_SAMPLE_RESOURCE = "src/test/resources/sample-testsuite-with-failed.xml";
+    private static final String PLUGIN_FILE_IN_IMAGE = "allure-jenkins-plugin.jpi";
+    private static final String JENKINS_INIT_FILE = "compat-init.groovy";
+    private static final Duration STARTUP_TIMEOUT = Duration.ofMinutes(10);
+    private static final Duration READY_TIMEOUT = Duration.ofMinutes(5);
+    private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(30);
+    private static final long POLL_DELAY_MS = 5_000L;
+
+    private static final List<String> REQUIRED_PLUGINS = List.of(
+            "bouncycastle-api:2.30.1.78.1-248.ve27176eb_46cb_",
+            "jackson2-api:2.17.0-389.va_5c7e45cd806",
+            "display-url-api:2.204.vf6fddd8a_8b_e9",
+            "matrix-project:839.vff91cd7e3a_b_2",
+            "workflow-basic-steps:1058.vcb_fc1e3a_21a_9",
+            "workflow-cps:4009.v0089238351a_9",
+            "workflow-durable-task-step:1378.v6a_3e903058a_3",
+            "workflow-job:1436.vfa_244484591f"
+    );
+
+    private final Configuration config;
+    private final HttpClient httpClient;
+
+    private JenkinsCompatibilitySmokeRunner(final Configuration config) {
+        this.config = config;
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .followRedirects(HttpClient.Redirect.NORMAL)
+                .build();
+    }
+
+    public static void main(final String[] args) throws Exception {
+        final Configuration config = Configuration.fromSystemProperties();
+        new JenkinsCompatibilitySmokeRunner(config).run();
+    }
+
+    private void run() throws Exception {
+        Files.createDirectories(config.artifactRoot());
+
+        final Path generatedDir = Files.createDirectories(config.artifactRoot().resolve("generated"));
+        final Path pluginArtifact = locatePluginArtifact(config.rootDir());
+        final Path passedSample = config.rootDir().resolve(PASSED_SAMPLE_RESOURCE);
+        final Path failedSample = config.rootDir().resolve(FAILED_SAMPLE_RESOURCE);
+        assertFileExists(passedSample, "sample passed results");
+        assertFileExists(failedSample, "sample failed results");
+
+        final String allureCliVersion = resolveAllureCliVersion(config.rootDir());
+        final Path pluginsTxt = writeTextFile(generatedDir.resolve("plugins.txt"), buildPluginsFile());
+        final Path initGroovy = writeTextFile(generatedDir.resolve(JENKINS_INIT_FILE), buildInitScript());
+        writeTextFile(config.artifactRoot().resolve("plugin-artifact.txt"), pluginArtifact.toString());
+        writeTextFile(config.artifactRoot().resolve("docker-image-tag.txt"), config.normalizedImageTag());
+
+        final ImageFromDockerfile image = createImage(pluginArtifact, passedSample, failedSample, pluginsTxt, initGroovy);
+        final List<SmokeCheck> checks = buildChecks();
+        final List<SmokeResult> results = new ArrayList<>();
+
+        GenericContainer<?> jenkins = null;
+        Throwable failure = null;
+        String baseUrl = null;
+
+        try {
+            jenkins = new GenericContainer<>(image)
+                    .withExposedPorts(8080)
+                    .withEnv("JAVA_OPTS", "-Djenkins.install.runSetupWizard=false")
+                    .waitingFor(Wait.forLogMessage(".*Jenkins is fully up and running.*\\n", 1))
+                    .withStartupTimeout(STARTUP_TIMEOUT);
+
+            jenkins.start();
+            baseUrl = "http://" + jenkins.getHost() + ":" + jenkins.getMappedPort(8080) + "/";
+            writeTextFile(config.artifactRoot().resolve("jenkins-base-url.txt"), baseUrl);
+
+            waitForScriptConsole(baseUrl);
+
+            final Path setupScriptPath = writeTextFile(
+                    generatedDir.resolve("setup.groovy"),
+                    buildSetupScript(allureCliVersion)
+            );
+            executeSetupScript(baseUrl, Files.readString(setupScriptPath, StandardCharsets.UTF_8));
+
+            for (SmokeCheck check : checks) {
+                results.add(runSmokeCheck(baseUrl, check, generatedDir));
+            }
+        } catch (Throwable throwable) {
+            failure = throwable;
+        } finally {
+            final String logs = jenkins == null ? "Jenkins container did not start." : jenkins.getLogs();
+            writeTextFile(config.artifactRoot().resolve("jenkins.log"), logs);
+
+            if (jenkins != null) {
+                jenkins.stop();
+            }
+
+            writeJsonReport(results, pluginArtifact, allureCliVersion, failure);
+            writeSummary(results, pluginArtifact, allureCliVersion, failure, baseUrl);
+        }
+
+        if (failure != null) {
+            if (failure instanceof Exception exception) {
+                throw exception;
+            }
+            throw new IllegalStateException("Compatibility smoke failed", failure);
+        }
+    }
+
+    private SmokeResult runSmokeCheck(final String baseUrl,
+                                      final SmokeCheck check,
+                                      final Path generatedDir) throws Exception {
+        final Path scriptPath = writeTextFile(
+                generatedDir.resolve(sanitizeFileName(check.jobName()) + ".groovy"),
+                buildCheckScript(check)
+        );
+        final JsonNode node = executeScriptForJson(baseUrl, Files.readString(scriptPath, StandardCharsets.UTF_8));
+
+        final JobSummary summary = new JobSummary(
+                node.path("summary").path("passed").asInt(),
+                node.path("summary").path("failed").asInt(),
+                node.path("summary").path("broken").asInt(),
+                node.path("summary").path("skipped").asInt(),
+                node.path("summary").path("unknown").asInt()
+        );
+
+        final List<ChildBuildResult> children = new ArrayList<>();
+        for (JsonNode child : node.path("children")) {
+            children.add(new ChildBuildResult(
+                    child.path("url").asText(),
+                    child.path("result").asText(),
+                    child.path("actionUrlName").asText(),
+                    new JobSummary(
+                            child.path("summary").path("passed").asInt(),
+                            child.path("summary").path("failed").asInt(),
+                            child.path("summary").path("broken").asInt(),
+                            child.path("summary").path("skipped").asInt(),
+                            child.path("summary").path("unknown").asInt()
+                    )
+            ));
+        }
+
+        final String buildUrl = node.path("buildUrl").asText();
+        final String actionUrlName = node.path("actionUrlName").asText();
+        final String reportUrl = joinUrl(baseUrl, buildUrl + actionUrlName + "/");
+        final String consoleUrl = joinUrl(baseUrl, buildUrl + "consoleText");
+
+        final HttpTextResponse reportPage = getText(reportUrl);
+        if (reportPage.statusCode() != 200) {
+            throw new IllegalStateException("Expected report endpoint for " + check.jobName()
+                    + " to return 200 but got " + reportPage.statusCode());
+        }
+
+        final HttpTextResponse consoleText = getText(consoleUrl);
+        final String baseFileName = sanitizeFileName(check.jobName());
+        writeTextFile(config.artifactRoot().resolve(baseFileName + "-report.html"), reportPage.body());
+        writeTextFile(config.artifactRoot().resolve(baseFileName + "-console.log"), consoleText.body());
+
+        return new SmokeResult(
+                check.jobName(),
+                node.path("result").asText(),
+                buildUrl,
+                reportUrl,
+                reportPage.statusCode(),
+                consoleUrl,
+                summary,
+                children
+        );
+    }
+
+    private void waitForScriptConsole(final String baseUrl) throws Exception {
+        final Instant deadline = Instant.now().plus(READY_TIMEOUT);
+        Exception lastFailure = null;
+        while (Instant.now().isBefore(deadline)) {
+            try {
+                final String response = executeScript(baseUrl, "println('ready')");
+                if ("ready".equals(response.trim())) {
+                    return;
+                }
+            } catch (Exception exception) {
+                lastFailure = exception;
+            }
+            sleepQuietly();
+        }
+
+        throw new IllegalStateException("Timed out waiting for Jenkins script console", lastFailure);
+    }
+
+    private void executeSetupScript(final String baseUrl, final String script) throws Exception {
+        final String response = executeScript(baseUrl, script).trim();
+        if (!"setup-complete".equals(response)) {
+            throw new IllegalStateException("Unexpected setup response from Jenkins:\n" + response);
+        }
+    }
+
+    private JsonNode executeScriptForJson(final String baseUrl, final String script) throws Exception {
+        final String response = executeScript(baseUrl, script).trim();
+        try {
+            return OBJECT_MAPPER.readTree(response);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Expected JSON response from Jenkins script but got:\n" + response,
+                    exception);
+        }
+    }
+
+    private String executeScript(final String baseUrl, final String script) throws Exception {
+        final String payload = "script=" + URLEncoder.encode(script, StandardCharsets.UTF_8);
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(joinUrl(baseUrl, "scriptText")))
+                .timeout(HTTP_TIMEOUT)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
+                .build();
+
+        final HttpResponse<String> response = httpClient.send(request,
+                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        if (response.statusCode() != 200) {
+            throw new IllegalStateException("Jenkins script console returned HTTP "
+                    + response.statusCode() + ":\n" + response.body());
+        }
+        return response.body();
+    }
+
+    private HttpTextResponse getText(final String url) throws Exception {
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                .timeout(HTTP_TIMEOUT)
+                .GET()
+                .build();
+        final HttpResponse<String> response = httpClient.send(request,
+                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        return new HttpTextResponse(response.statusCode(), response.body());
+    }
+
+    private ImageFromDockerfile createImage(final Path pluginArtifact,
+                                            final Path passedSample,
+                                            final Path failedSample,
+                                            final Path pluginsTxt,
+                                            final Path initGroovy) {
+        final String imageName = "allure-jenkins-compat-"
+                + Integer.toHexString(config.normalizedImageTag().hashCode()).toLowerCase(Locale.ROOT);
+
+        return new ImageFromDockerfile(imageName, false)
+                .withFileFromPath("plugins.txt", pluginsTxt)
+                .withFileFromPath(JENKINS_INIT_FILE, initGroovy)
+                .withFileFromPath("sample-testsuite.xml", passedSample)
+                .withFileFromPath("sample-testsuite-with-failed.xml", failedSample)
+                .withFileFromPath(PLUGIN_FILE_IN_IMAGE, pluginArtifact)
+                .withDockerfileFromBuilder(builder -> builder
+                        .from("jenkins/jenkins:" + config.normalizedImageTag())
+                        .user("root")
+                        .run("mkdir -p /usr/share/jenkins/ref/plugins /usr/share/jenkins/ref/smoke-data /usr/share/jenkins/ref/init.groovy.d")
+                        .copy("plugins.txt", "/usr/share/jenkins/ref/plugins.txt")
+                        .run("chown -R jenkins:jenkins /usr/share/jenkins/ref")
+                        .user("jenkins")
+                        .run("jenkins-plugin-cli --latest=false --plugin-file /usr/share/jenkins/ref/plugins.txt")
+                        .run("echo 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state")
+                        .user("root")
+                        .copy(JENKINS_INIT_FILE, "/usr/share/jenkins/ref/init.groovy.d/" + JENKINS_INIT_FILE)
+                        .copy("sample-testsuite.xml", SMOKE_DATA_DIR + "/sample-testsuite.xml")
+                        .copy("sample-testsuite-with-failed.xml", SMOKE_DATA_DIR + "/sample-testsuite-with-failed.xml")
+                        .copy(PLUGIN_FILE_IN_IMAGE, "/usr/share/jenkins/ref/plugins/" + PLUGIN_FILE_IN_IMAGE)
+                        .run("chown -R jenkins:jenkins /usr/share/jenkins/ref")
+                        .user("jenkins")
+                        .build());
+    }
+
+    private Path locatePluginArtifact(final Path rootDir) throws IOException {
+        final Path targetDir = rootDir.resolve("target");
+        if (Files.notExists(targetDir)) {
+            throw new IllegalStateException("Plugin target directory does not exist: " + targetDir);
+        }
+
+        try (Stream<Path> stream = Files.list(targetDir)) {
+            final List<Path> matches = stream
+                    .filter(path -> path.getFileName().toString().endsWith(".hpi"))
+                    .sorted()
+                    .toList();
+            if (matches.isEmpty()) {
+                throw new IllegalStateException("No plugin .hpi artifact found in " + targetDir);
+            }
+            return matches.get(0);
+        }
+    }
+
+    private String resolveAllureCliVersion(final Path rootDir) throws IOException {
+        final String override = System.getProperty("compat.allureCliVersion");
+        if (override != null && !override.isBlank()) {
+            return override.trim();
+        }
+
+        final String pom = Files.readString(rootDir.resolve("pom.xml"), StandardCharsets.UTF_8);
+        final Matcher matcher = ALLURE_CLI_VERSION_PATTERN.matcher(pom);
+        if (matcher.find()) {
+            return matcher.group(1).trim();
+        }
+
+        throw new IllegalStateException("Unable to resolve allureCommandline.version from root pom.xml");
+    }
+
+    private String buildPluginsFile() {
+        return REQUIRED_PLUGINS.stream().collect(Collectors.joining(System.lineSeparator())) + System.lineSeparator();
+    }
+
+    private String buildInitScript() {
+        return """
+                import hudson.security.AuthorizationStrategy
+                import hudson.security.SecurityRealm
+                import jenkins.model.Jenkins
+
+                def jenkins = Jenkins.get()
+                jenkins.setNumExecutors(2)
+                jenkins.setSecurityRealm(SecurityRealm.NO_AUTHENTICATION)
+                jenkins.setAuthorizationStrategy(new AuthorizationStrategy.Unsecured())
+                jenkins.setCrumbIssuer(null)
+                jenkins.save()
+                """;
+    }
+
+    private String buildSetupScript(final String allureCliVersion) {
+        final String allureVersionLiteral = groovyStringLiteral(allureCliVersion);
+        final String passedSampleLiteral = groovyStringLiteral(SMOKE_DATA_DIR + "/sample-testsuite.xml");
+        final String failedSampleLiteral = groovyStringLiteral(SMOKE_DATA_DIR + "/sample-testsuite-with-failed.xml");
+
+        return """
+                import hudson.matrix.Axis
+                import hudson.matrix.MatrixProject
+                import hudson.model.FreeStyleProject
+                import hudson.tasks.Shell
+                import hudson.tools.InstallSourceProperty
+                import jenkins.model.Jenkins
+                import org.allurereport.jenkins.AllureReportPublisher
+                import org.allurereport.jenkins.config.ResultsConfig
+                import org.allurereport.jenkins.tools.AllureCommandlineDirectInstaller
+                import org.allurereport.jenkins.tools.AllureCommandlineInstallation
+                import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition
+                import org.jenkinsci.plugins.workflow.job.WorkflowJob
+
+                def jenkins = Jenkins.get()
+                def allureVersion = %s
+                def passedSample = %s
+                def failedSample = %s
+                def toolDescriptor = jenkins.getDescriptorByType(AllureCommandlineInstallation.DescriptorImpl.class)
+
+                if (toolDescriptor.installations.length == 0) {
+                    def installer = new AllureCommandlineDirectInstaller(allureVersion)
+                    def installation = new AllureCommandlineInstallation(
+                        "Allure " + allureVersion,
+                        "",
+                        [new InstallSourceProperty([installer])]
+                    )
+                    toolDescriptor.setInstallations(installation)
+                    toolDescriptor.save()
+                }
+
+                def createPublisher = { ->
+                    new AllureReportPublisher(ResultsConfig.convertPaths(['allure-results']))
+                }
+
+                def ensureFreestyle = { String jobName, String dataFile, Integer failureThreshold ->
+                    def job = jenkins.getItem(jobName)
+                    if (!(job instanceof FreeStyleProject)) {
+                        if (job != null) {
+                            job.delete()
+                        }
+                        job = jenkins.createProject(FreeStyleProject, jobName)
+                    }
+
+                    job.buildersList.clear()
+                    job.publishersList.clear()
+                    job.buildersList.add(new Shell(\"\"\"#!/bin/bash -e
+                    mkdir -p allure-results
+                    cp ${dataFile} allure-results/${new File(dataFile).getName()}
+                    \"\"\".stripIndent()))
+
+                    def publisher = createPublisher()
+                    if (failureThreshold != null) {
+                        publisher.setFailureThresholdCount(failureThreshold)
+                    }
+                    job.publishersList.add(publisher)
+                    job.save()
+                }
+
+                ensureFreestyle('compat-freestyle', passedSample, null)
+
+                def pipeline = jenkins.getItem('compat-pipeline')
+                if (!(pipeline instanceof WorkflowJob)) {
+                    if (pipeline != null) {
+                        pipeline.delete()
+                    }
+                    pipeline = jenkins.createProject(WorkflowJob, 'compat-pipeline')
+                }
+                pipeline.setDefinition(new CpsFlowDefinition(\"\"\"node {
+                  sh '''#!/bin/bash -e
+                  mkdir -p allure-results
+                  cp %s allure-results/sample-testsuite.xml
+                  '''
+                  allure results: [[path: 'allure-results']]
+                }\"\"\".stripIndent(), true))
+                pipeline.save()
+
+                def matrix = jenkins.getItem('compat-matrix')
+                if (!(matrix instanceof MatrixProject)) {
+                    if (matrix != null) {
+                        matrix.delete()
+                    }
+                    matrix = jenkins.createProject(MatrixProject, 'compat-matrix')
+                }
+                matrix.axes.clear()
+                matrix.axes.add(new Axis('items', 'first', 'second'))
+                matrix.buildersList.clear()
+                matrix.publishersList.clear()
+                matrix.buildersList.add(new Shell(\"\"\"#!/bin/bash -e
+                mkdir -p allure-results
+                cp ${passedSample} allure-results/sample-testsuite.xml
+                \"\"\".stripIndent()))
+                matrix.publishersList.add(createPublisher())
+                matrix.save()
+
+                jenkins.save()
+                println('setup-complete')
+                """.formatted(
+                allureVersionLiteral,
+                passedSampleLiteral,
+                failedSampleLiteral,
+                passedSampleLiteral
+        );
+    }
+
+    private String buildCheckScript(final SmokeCheck check) {
+        if (check.matrix()) {
+            return buildMatrixCheckScript(check);
+        }
+        return buildStandardCheckScript(check);
+    }
+
+    private String buildStandardCheckScript(final SmokeCheck check) {
+        return """
+                import groovy.json.JsonOutput
+                import jenkins.model.Jenkins
+                import org.allurereport.jenkins.AllureReportBuildAction
+
+                def job = Jenkins.get().getItemByFullName(%s)
+                if (job == null) {
+                    throw new IllegalStateException("Job not found: " + %s)
+                }
+
+                def future = job.scheduleBuild2(0)
+                if (future == null) {
+                    throw new IllegalStateException("Failed to schedule build for " + job.fullName)
+                }
+
+                def build = future.get()
+                def action = build.getAction(AllureReportBuildAction)
+                if (action == null) {
+                    throw new IllegalStateException("Allure action is missing for " + job.fullName)
+                }
+
+                def summary = action.getBuildSummary()
+                def buildResult = String.valueOf(build.getResult())
+                if (buildResult != %s) {
+                    throw new IllegalStateException("Expected result %s but got " + buildResult)
+                }
+                if (summary.getPassedCount() != %d || summary.getFailedCount() != %d) {
+                    throw new IllegalStateException("Unexpected summary for " + job.fullName + ": "
+                        + "passed=" + summary.getPassedCount() + ", failed=" + summary.getFailedCount())
+                }
+
+                println(JsonOutput.toJson([
+                    job: job.fullName,
+                    result: buildResult,
+                    buildUrl: build.getUrl(),
+                    actionUrlName: action.getUrlName(),
+                    summary: [
+                        passed: summary.getPassedCount(),
+                        failed: summary.getFailedCount(),
+                        broken: summary.getBrokenCount(),
+                        skipped: summary.getSkipCount(),
+                        unknown: summary.getUnknownCount()
+                    ],
+                    children: []
+                ]))
+                """.formatted(
+                groovyStringLiteral(check.jobName()),
+                groovyStringLiteral(check.jobName()),
+                groovyStringLiteral(check.expectedResult()),
+                groovyStringLiteral(check.expectedResult()),
+                check.expectedPassed(),
+                check.expectedFailed()
+        );
+    }
+
+    private String buildMatrixCheckScript(final SmokeCheck check) {
+        return """
+                import groovy.json.JsonOutput
+                import jenkins.model.Jenkins
+                import org.allurereport.jenkins.AllureReportBuildAction
+
+                def job = Jenkins.get().getItemByFullName(%s)
+                if (job == null) {
+                    throw new IllegalStateException("Job not found: " + %s)
+                }
+
+                def future = job.scheduleBuild2(0)
+                if (future == null) {
+                    throw new IllegalStateException("Failed to schedule build for " + job.fullName)
+                }
+
+                def build = future.get()
+                def action = build.getAction(AllureReportBuildAction)
+                if (action == null) {
+                    throw new IllegalStateException("Allure parent action is missing for " + job.fullName)
+                }
+
+                def summary = action.getBuildSummary()
+                def buildResult = String.valueOf(build.getResult())
+                if (buildResult != %s) {
+                    throw new IllegalStateException("Expected result %s but got " + buildResult)
+                }
+
+                def runs = build.getRuns().toList().sort { a, b -> a.getUrl() <=> b.getUrl() }
+                if (runs.size() != 2) {
+                    throw new IllegalStateException("Expected 2 matrix runs but got " + runs.size())
+                }
+
+                def children = runs.collect { run ->
+                    def childAction = run.getAction(AllureReportBuildAction)
+                    if (childAction == null) {
+                        throw new IllegalStateException("Child Allure action is missing for " + run.getUrl())
+                    }
+                    def childSummary = childAction.getBuildSummary()
+                    def childResult = String.valueOf(run.getResult())
+                    if (childResult != 'SUCCESS') {
+                        throw new IllegalStateException("Expected matrix child success but got " + childResult)
+                    }
+                    if (childSummary.getPassedCount() != 1 || childSummary.getFailedCount() != 0) {
+                        throw new IllegalStateException("Unexpected child summary for " + run.getUrl())
+                    }
+                    [
+                        url: run.getUrl(),
+                        result: childResult,
+                        actionUrlName: childAction.getUrlName(),
+                        summary: [
+                            passed: childSummary.getPassedCount(),
+                            failed: childSummary.getFailedCount(),
+                            broken: childSummary.getBrokenCount(),
+                            skipped: childSummary.getSkipCount(),
+                            unknown: childSummary.getUnknownCount()
+                        ]
+                    ]
+                }
+
+                println(JsonOutput.toJson([
+                    job: job.fullName,
+                    result: buildResult,
+                    buildUrl: build.getUrl(),
+                    actionUrlName: action.getUrlName(),
+                    summary: [
+                        passed: summary.getPassedCount(),
+                        failed: summary.getFailedCount(),
+                        broken: summary.getBrokenCount(),
+                        skipped: summary.getSkipCount(),
+                        unknown: summary.getUnknownCount()
+                    ],
+                    children: children
+                ]))
+                """.formatted(
+                groovyStringLiteral(check.jobName()),
+                groovyStringLiteral(check.jobName()),
+                groovyStringLiteral(check.expectedResult()),
+                groovyStringLiteral(check.expectedResult())
+        );
+    }
+
+    private List<SmokeCheck> buildChecks() {
+        return List.of(
+                new SmokeCheck("compat-freestyle", "SUCCESS", 1, 0, false),
+                new SmokeCheck("compat-pipeline", "SUCCESS", 1, 0, false),
+                new SmokeCheck("compat-matrix", "SUCCESS", 2, 0, true)
+        );
+    }
+
+    private void writeJsonReport(final List<SmokeResult> results,
+                                 final Path pluginArtifact,
+                                 final String allureCliVersion,
+                                 final Throwable failure) throws IOException {
+        final Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("requestedVersion", config.requestedVersion());
+        payload.put("jenkinsImageTag", config.normalizedImageTag());
+        payload.put("pluginArtifact", pluginArtifact.toString());
+        payload.put("allureCliVersion", allureCliVersion);
+        payload.put("results", results);
+        payload.put("failure", failure == null ? null : failure.toString());
+        OBJECT_MAPPER.writerWithDefaultPrettyPrinter()
+                .writeValue(config.artifactRoot().resolve("results.json").toFile(), payload);
+    }
+
+    private void writeSummary(final List<SmokeResult> results,
+                              final Path pluginArtifact,
+                              final String allureCliVersion,
+                              final Throwable failure,
+                              final String baseUrl) throws IOException {
+        final StringBuilder summary = new StringBuilder();
+        summary.append("# Jenkins Compatibility Smoke").append(System.lineSeparator()).append(System.lineSeparator());
+        summary.append("- Requested Jenkins version: `").append(config.requestedVersion()).append('`')
+                .append(System.lineSeparator());
+        summary.append("- Jenkins Docker tag: `").append(config.normalizedImageTag()).append('`')
+                .append(System.lineSeparator());
+        summary.append("- Plugin artifact: `").append(pluginArtifact).append('`')
+                .append(System.lineSeparator());
+        summary.append("- Allure CLI version: `").append(allureCliVersion).append('`')
+                .append(System.lineSeparator());
+        if (baseUrl != null) {
+            summary.append("- Jenkins base URL: `").append(baseUrl).append('`')
+                    .append(System.lineSeparator());
+        }
+        summary.append(System.lineSeparator());
+        summary.append("| Job | Result | Report | Passed | Failed |").append(System.lineSeparator());
+        summary.append("| --- | --- | --- | --- | --- |").append(System.lineSeparator());
+        for (SmokeResult result : results) {
+            summary.append("| ")
+                    .append(result.jobName())
+                    .append(" | ")
+                    .append(result.result())
+                    .append(" | ")
+                    .append(result.reportStatusCode())
+                    .append(" | ")
+                    .append(result.summary().passed())
+                    .append(" | ")
+                    .append(result.summary().failed())
+                    .append(" |")
+                    .append(System.lineSeparator());
+        }
+        if (failure != null) {
+            summary.append(System.lineSeparator())
+                    .append("## Failure").append(System.lineSeparator()).append(System.lineSeparator())
+                    .append("```").append(System.lineSeparator())
+                    .append(failure).append(System.lineSeparator())
+                    .append("```").append(System.lineSeparator());
+        }
+
+        writeTextFile(config.artifactRoot().resolve("summary.md"), summary.toString());
+    }
+
+    private Path writeTextFile(final Path path, final String content) throws IOException {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    private static void assertFileExists(final Path path, final String description) {
+        if (Files.notExists(path)) {
+            throw new IllegalStateException("Missing " + description + " file: " + path);
+        }
+    }
+
+    private void sleepQuietly() throws InterruptedException {
+        Thread.sleep(POLL_DELAY_MS);
+    }
+
+    private static String joinUrl(final String baseUrl, final String relative) {
+        return baseUrl.endsWith("/") ? baseUrl + relative : baseUrl + "/" + relative;
+    }
+
+    private static String groovyStringLiteral(final String value) {
+        return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'";
+    }
+
+    private static String sanitizeFileName(final String value) {
+        return value.replaceAll("[^A-Za-z0-9._-]", "_");
+    }
+
+    private record Configuration(Path rootDir,
+                                 String requestedVersion,
+                                 String normalizedImageTag,
+                                 Path artifactRoot) {
+
+        private static Configuration fromSystemProperties() {
+            final Path rootDir = Path.of(System.getProperty("compat.rootDir", ".")).toAbsolutePath().normalize();
+            final String requestedVersion = System.getProperty("compat.version", "2.462.1").trim();
+            final String normalizedImageTag = normalizeJenkinsImageTag(requestedVersion);
+            final Path artifactRoot = Path.of(System.getProperty(
+                    "compat.artifactRoot",
+                    rootDir.resolve("compat-artifacts").resolve(sanitizeFileName(requestedVersion)).toString()
+            )).toAbsolutePath().normalize();
+
+            return new Configuration(rootDir, requestedVersion, normalizedImageTag, artifactRoot);
+        }
+
+        private static String normalizeJenkinsImageTag(final String requestedVersion) {
+            if (requestedVersion.contains(":")) {
+                throw new IllegalArgumentException("compat.version must be a Jenkins Docker tag or bare version, "
+                        + "not a full image reference: " + requestedVersion);
+            }
+            if (requestedVersion.contains("jdk") || requestedVersion.contains("lts")
+                    || requestedVersion.contains("alpine")) {
+                return requestedVersion;
+            }
+            return requestedVersion + "-lts-jdk17";
+        }
+    }
+
+    private record SmokeCheck(String jobName,
+                              String expectedResult,
+                              int expectedPassed,
+                              int expectedFailed,
+                              boolean matrix) {
+    }
+
+    private record JobSummary(int passed, int failed, int broken, int skipped, int unknown) {
+    }
+
+    private record ChildBuildResult(String url,
+                                    String result,
+                                    String actionUrlName,
+                                    JobSummary summary) {
+    }
+
+    private record SmokeResult(String jobName,
+                               String result,
+                               String buildUrl,
+                               String reportUrl,
+                               int reportStatusCode,
+                               String consoleUrl,
+                               JobSummary summary,
+                               List<ChildBuildResult> children) {
+    }
+
+    private record HttpTextResponse(int statusCode, String body) {
+    }
+}

--- a/compat/jenkins-smoke/src/test/java/org/allurereport/jenkins/compat/JenkinsCompatibilitySmokeTest.java
+++ b/compat/jenkins-smoke/src/test/java/org/allurereport/jenkins/compat/JenkinsCompatibilitySmokeTest.java
@@ -17,9 +17,21 @@ package org.allurereport.jenkins.compat;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.qameta.allure.Allure;
+import io.qameta.allure.Description;
+import io.qameta.allure.Epic;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.io.IOException;
 import java.net.URI;
@@ -32,21 +44,25 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 /**
  * Starts a real Jenkins in Docker, installs the plugin under test, configures smoke jobs,
  * and verifies the main plugin flows against a requested Jenkins version.
  */
-public final class JenkinsCompatibilitySmokeRunner {
+@Epic("Compatibility")
+@Feature("Jenkins smoke")
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class JenkinsCompatibilitySmokeTest {
 
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
@@ -55,16 +71,17 @@ public final class JenkinsCompatibilitySmokeRunner {
 
     private static final String SMOKE_DATA_DIR = "/usr/share/jenkins/ref/smoke-data";
     private static final String PASSED_SAMPLE_RESOURCE = "src/test/resources/sample-testsuite.xml";
-    private static final String FAILED_SAMPLE_RESOURCE = "src/test/resources/sample-testsuite-with-failed.xml";
     private static final String PLUGIN_FILE_IN_IMAGE = "allure-jenkins-plugin.jpi";
     private static final String JENKINS_INIT_FILE = "compat-init.groovy";
     private static final Duration STARTUP_TIMEOUT = Duration.ofMinutes(10);
     private static final Duration READY_TIMEOUT = Duration.ofMinutes(5);
     private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration SMOKE_CHECK_TIMEOUT = Duration.ofMinutes(10);
     private static final long POLL_DELAY_MS = 5_000L;
 
     private static final List<String> REQUIRED_PLUGINS = List.of(
             "bouncycastle-api:2.30.1.78.1-248.ve27176eb_46cb_",
+            "commons-lang3-api:3.17.0-84.vb_b_938040b_078",
             "jackson2-api:2.17.0-389.va_5c7e45cd806",
             "display-url-api:2.204.vf6fddd8a_8b_e9",
             "matrix-project:839.vff91cd7e3a_b_2",
@@ -74,157 +91,183 @@ public final class JenkinsCompatibilitySmokeRunner {
             "workflow-job:1436.vfa_244484591f"
     );
 
-    private final Configuration config;
-    private final HttpClient httpClient;
+    private static final TestHarness TEST_HARNESS = createTestHarness();
 
-    private JenkinsCompatibilitySmokeRunner(final Configuration config) {
-        this.config = config;
-        this.httpClient = HttpClient.newBuilder()
-                .connectTimeout(Duration.ofSeconds(10))
-                .followRedirects(HttpClient.Redirect.NORMAL)
-                .build();
-    }
+    @Container
+    private static final GenericContainer<?> JENKINS = TEST_HARNESS.createContainer();
 
-    public static void main(final String[] args) throws Exception {
-        final Configuration config = Configuration.fromSystemProperties();
-        new JenkinsCompatibilitySmokeRunner(config).run();
-    }
+    private final Configuration config = TEST_HARNESS.config();
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+    private final Path generatedDir = TEST_HARNESS.generatedDir();
+    private final Path pluginArtifact = TEST_HARNESS.pluginArtifact();
+    private final String allureCliVersion = TEST_HARNESS.allureCliVersion();
+    private String baseUrl;
 
-    private void run() throws Exception {
-        Files.createDirectories(config.artifactRoot());
-
-        final Path generatedDir = Files.createDirectories(config.artifactRoot().resolve("generated"));
-        final Path pluginArtifact = locatePluginArtifact(config.rootDir());
-        final Path passedSample = config.rootDir().resolve(PASSED_SAMPLE_RESOURCE);
-        final Path failedSample = config.rootDir().resolve(FAILED_SAMPLE_RESOURCE);
-        assertFileExists(passedSample, "sample passed results");
-        assertFileExists(failedSample, "sample failed results");
-
-        final String allureCliVersion = resolveAllureCliVersion(config.rootDir());
-        final Path pluginsTxt = writeTextFile(generatedDir.resolve("plugins.txt"), buildPluginsFile());
-        final Path initGroovy = writeTextFile(generatedDir.resolve(JENKINS_INIT_FILE), buildInitScript());
+    @BeforeAll
+    void setUp() throws Exception {
         writeTextFile(config.artifactRoot().resolve("plugin-artifact.txt"), pluginArtifact.toString());
         writeTextFile(config.artifactRoot().resolve("docker-image-tag.txt"), config.normalizedImageTag());
+        baseUrl = "http://" + JENKINS.getHost() + ":" + JENKINS.getMappedPort(8080) + "/";
+        writeTextFile(config.artifactRoot().resolve("jenkins-base-url.txt"), baseUrl);
+        writeAllureEnvironment();
 
-        final ImageFromDockerfile image = createImage(pluginArtifact, passedSample, failedSample, pluginsTxt, initGroovy);
-        final List<SmokeCheck> checks = buildChecks();
-        final List<SmokeResult> results = new ArrayList<>();
+        waitForScriptConsole();
 
-        GenericContainer<?> jenkins = null;
-        Throwable failure = null;
-        String baseUrl = null;
+        final Path setupScriptPath = writeTextFile(
+                generatedDir.resolve("setup.groovy"),
+                buildSetupScript(allureCliVersion)
+        );
+        executeSetupScript(Files.readString(setupScriptPath, StandardCharsets.UTF_8));
+    }
 
+    @AfterAll
+    void tearDown() throws Exception {
+        final String logs = JENKINS.isRunning() ? JENKINS.getLogs() : "Jenkins container did not start.";
+        writeTextFile(config.artifactRoot().resolve("jenkins.log"), logs);
+    }
+
+    @Test
+    @DisplayName("Freestyle job generates Allure report")
+    @Story("Freestyle report generation")
+    @Description("Runs a freestyle Jenkins job and verifies that the plugin publishes an Allure report action.")
+    void shouldGenerateFreestyleReport() throws Exception {
+        runWithAllure(new SmokeCheck("compat-freestyle", "SUCCESS", 1, 0, false));
+    }
+
+    @Test
+    @DisplayName("Pipeline job runs allure step")
+    @Story("Pipeline step execution")
+    @Description("Runs a Jenkins Pipeline that invokes the allure step and verifies the published report.")
+    void shouldRunPipelineStep() throws Exception {
+        runWithAllure(new SmokeCheck("compat-pipeline", "SUCCESS", 1, 0, false));
+    }
+
+    @Test
+    @DisplayName("Matrix job generates parent and child Allure reports")
+    @Story("Matrix aggregation")
+    @Description("Runs a matrix Jenkins job and verifies the parent and child Allure reports are generated.")
+    void shouldGenerateMatrixReports() throws Exception {
+        runWithAllure(new SmokeCheck("compat-matrix", "SUCCESS", 2, 0, true));
+    }
+
+    private void runWithAllure(final SmokeCheck check) throws Exception {
+        addAllureParameters(check);
         try {
-            jenkins = new GenericContainer<>(image)
-                    .withExposedPorts(8080)
-                    .withEnv("JAVA_OPTS", "-Djenkins.install.runSetupWizard=false")
-                    .waitingFor(Wait.forLogMessage(".*Jenkins is fully up and running.*\\n", 1))
-                    .withStartupTimeout(STARTUP_TIMEOUT);
-
-            jenkins.start();
-            baseUrl = "http://" + jenkins.getHost() + ":" + jenkins.getMappedPort(8080) + "/";
-            writeTextFile(config.artifactRoot().resolve("jenkins-base-url.txt"), baseUrl);
-
-            waitForScriptConsole(baseUrl);
-
-            final Path setupScriptPath = writeTextFile(
-                    generatedDir.resolve("setup.groovy"),
-                    buildSetupScript(allureCliVersion)
-            );
-            executeSetupScript(baseUrl, Files.readString(setupScriptPath, StandardCharsets.UTF_8));
-
-            for (SmokeCheck check : checks) {
-                results.add(runSmokeCheck(baseUrl, check, generatedDir));
-            }
-        } catch (Throwable throwable) {
-            failure = throwable;
-        } finally {
-            final String logs = jenkins == null ? "Jenkins container did not start." : jenkins.getLogs();
-            writeTextFile(config.artifactRoot().resolve("jenkins.log"), logs);
-
-            if (jenkins != null) {
-                jenkins.stop();
-            }
-
-            writeJsonReport(results, pluginArtifact, allureCliVersion, failure);
-            writeSummary(results, pluginArtifact, allureCliVersion, failure, baseUrl);
-        }
-
-        if (failure != null) {
-            if (failure instanceof Exception exception) {
-                throw exception;
-            }
-            throw new IllegalStateException("Compatibility smoke failed", failure);
+            runSmokeCheck(check);
+        } catch (Exception exception) {
+            attachJenkinsControllerLog();
+            throw exception;
+        } catch (AssertionError error) {
+            attachJenkinsControllerLog();
+            throw error;
         }
     }
 
-    private SmokeResult runSmokeCheck(final String baseUrl,
-                                      final SmokeCheck check,
-                                      final Path generatedDir) throws Exception {
+    private void runSmokeCheck(final SmokeCheck check) throws Exception {
+        final String script = buildCheckScript(check);
         final Path scriptPath = writeTextFile(
                 generatedDir.resolve(sanitizeFileName(check.jobName()) + ".groovy"),
-                buildCheckScript(check)
+                script
         );
-        final JsonNode node = executeScriptForJson(baseUrl, Files.readString(scriptPath, StandardCharsets.UTF_8));
-
-        final JobSummary summary = new JobSummary(
-                node.path("summary").path("passed").asInt(),
-                node.path("summary").path("failed").asInt(),
-                node.path("summary").path("broken").asInt(),
-                node.path("summary").path("skipped").asInt(),
-                node.path("summary").path("unknown").asInt()
-        );
-
-        final List<ChildBuildResult> children = new ArrayList<>();
-        for (JsonNode child : node.path("children")) {
-            children.add(new ChildBuildResult(
-                    child.path("url").asText(),
-                    child.path("result").asText(),
-                    child.path("actionUrlName").asText(),
-                    new JobSummary(
-                            child.path("summary").path("passed").asInt(),
-                            child.path("summary").path("failed").asInt(),
-                            child.path("summary").path("broken").asInt(),
-                            child.path("summary").path("skipped").asInt(),
-                            child.path("summary").path("unknown").asInt()
-                    )
-            ));
-        }
+        Allure.parameter("Groovy check script", scriptPath.toString());
+        final JsonNode node = Allure.step("Run " + check.jobName() + " and verify its Allure summary", () -> {
+            Allure.addAttachment(check.jobName() + " Groovy check", "text/x-groovy", script, ".groovy");
+            final JsonNode response = executeScriptForJson(script);
+            Allure.addAttachment(
+                    check.jobName() + " Jenkins smoke response",
+                    "application/json",
+                    OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(response),
+                    ".json"
+            );
+            return response;
+        });
 
         final String buildUrl = node.path("buildUrl").asText();
         final String actionUrlName = node.path("actionUrlName").asText();
+        final String absoluteBuildUrl = joinUrl(baseUrl, buildUrl);
         final String reportUrl = joinUrl(baseUrl, buildUrl + actionUrlName + "/");
         final String consoleUrl = joinUrl(baseUrl, buildUrl + "consoleText");
+        Allure.link(check.jobName() + " Jenkins build", absoluteBuildUrl);
+        Allure.link(check.jobName() + " Allure report", reportUrl);
+        addChildReportLinks(check, node);
 
-        final HttpTextResponse reportPage = getText(reportUrl);
-        if (reportPage.statusCode() != 200) {
-            throw new IllegalStateException("Expected report endpoint for " + check.jobName()
-                    + " to return 200 but got " + reportPage.statusCode());
-        }
+        final HttpTextResponse reportPage = Allure.step(
+                "Verify the published Allure report for " + check.jobName(),
+                () -> {
+                    final HttpTextResponse response = getText(reportUrl);
+                    Allure.addAttachment(check.jobName() + " report page", "text/html", response.body(), ".html");
+                    assertEquals(200, response.statusCode(),
+                            () -> "Unexpected report endpoint status for " + check.jobName());
+                    return response;
+                }
+        );
+        addJenkinsResultParameters(node, reportUrl, consoleUrl, reportPage.statusCode());
 
-        final HttpTextResponse consoleText = getText(consoleUrl);
+        final HttpTextResponse consoleText = Allure.step(
+                "Capture the Jenkins console for " + check.jobName(),
+                () -> {
+                    final HttpTextResponse response = getText(consoleUrl);
+                    Allure.addAttachment(check.jobName() + " console", "text/plain", response.body(), ".log");
+                    return response;
+                }
+        );
         final String baseFileName = sanitizeFileName(check.jobName());
         writeTextFile(config.artifactRoot().resolve(baseFileName + "-report.html"), reportPage.body());
         writeTextFile(config.artifactRoot().resolve(baseFileName + "-console.log"), consoleText.body());
-
-        return new SmokeResult(
-                check.jobName(),
-                node.path("result").asText(),
-                buildUrl,
-                reportUrl,
-                reportPage.statusCode(),
-                consoleUrl,
-                summary,
-                children
-        );
     }
 
-    private void waitForScriptConsole(final String baseUrl) throws Exception {
+    private void addAllureParameters(final SmokeCheck check) {
+        Allure.parameter("Jenkins requested version", config.requestedVersion());
+        Allure.parameter("Jenkins Docker tag", config.normalizedImageTag());
+        Allure.parameter("Jenkins base URL", baseUrl);
+        Allure.parameter("Plugin artifact", pluginArtifact.toString());
+        Allure.parameter("Allure CLI version", allureCliVersion);
+        Allure.parameter("Smoke job", check.jobName());
+        Allure.parameter("Expected build result", check.expectedResult());
+        Allure.parameter("Expected passed tests", check.expectedPassed());
+        Allure.parameter("Expected failed tests", check.expectedFailed());
+    }
+
+    private void addJenkinsResultParameters(final JsonNode node,
+                                            final String reportUrl,
+                                            final String consoleUrl,
+                                            final int reportStatusCode) {
+        Allure.parameter("Build result", node.path("result").asText());
+        Allure.parameter("Report URL", reportUrl);
+        Allure.parameter("Report HTTP status", reportStatusCode);
+        Allure.parameter("Console URL", consoleUrl);
+        Allure.parameter("Passed tests", node.path("summary").path("passed").asInt());
+        Allure.parameter("Failed tests", node.path("summary").path("failed").asInt());
+        Allure.parameter("Broken tests", node.path("summary").path("broken").asInt());
+        Allure.parameter("Skipped tests", node.path("summary").path("skipped").asInt());
+        Allure.parameter("Unknown tests", node.path("summary").path("unknown").asInt());
+    }
+
+    private void addChildReportLinks(final SmokeCheck check, final JsonNode node) {
+        for (JsonNode child : node.path("children")) {
+            final String childReportUrl = joinUrl(
+                    baseUrl,
+                    child.path("url").asText() + child.path("actionUrlName").asText() + "/"
+            );
+            Allure.link(check.jobName() + " child " + child.path("url").asText(), childReportUrl);
+        }
+    }
+
+    private void attachJenkinsControllerLog() {
+        if (JENKINS.isRunning()) {
+            Allure.addAttachment("Jenkins controller log", "text/plain", JENKINS.getLogs(), ".log");
+        }
+    }
+
+    private void waitForScriptConsole() throws Exception {
         final Instant deadline = Instant.now().plus(READY_TIMEOUT);
         Exception lastFailure = null;
         while (Instant.now().isBefore(deadline)) {
             try {
-                final String response = executeScript(baseUrl, "println('ready')");
+                final String response = executeScript("println('ready')");
                 if ("ready".equals(response.trim())) {
                     return;
                 }
@@ -237,15 +280,15 @@ public final class JenkinsCompatibilitySmokeRunner {
         throw new IllegalStateException("Timed out waiting for Jenkins script console", lastFailure);
     }
 
-    private void executeSetupScript(final String baseUrl, final String script) throws Exception {
-        final String response = executeScript(baseUrl, script).trim();
+    private void executeSetupScript(final String script) throws Exception {
+        final String response = executeScript(script).trim();
         if (!"setup-complete".equals(response)) {
             throw new IllegalStateException("Unexpected setup response from Jenkins:\n" + response);
         }
     }
 
-    private JsonNode executeScriptForJson(final String baseUrl, final String script) throws Exception {
-        final String response = executeScript(baseUrl, script).trim();
+    private JsonNode executeScriptForJson(final String script) throws Exception {
+        final String response = executeScript(script, SMOKE_CHECK_TIMEOUT).trim();
         try {
             return OBJECT_MAPPER.readTree(response);
         } catch (IOException exception) {
@@ -254,10 +297,14 @@ public final class JenkinsCompatibilitySmokeRunner {
         }
     }
 
-    private String executeScript(final String baseUrl, final String script) throws Exception {
+    private String executeScript(final String script) throws Exception {
+        return executeScript(script, HTTP_TIMEOUT);
+    }
+
+    private String executeScript(final String script, final Duration timeout) throws Exception {
         final String payload = "script=" + URLEncoder.encode(script, StandardCharsets.UTF_8);
         final HttpRequest request = HttpRequest.newBuilder(URI.create(joinUrl(baseUrl, "scriptText")))
-                .timeout(HTTP_TIMEOUT)
+                .timeout(timeout)
                 .header("Content-Type", "application/x-www-form-urlencoded")
                 .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
                 .build();
@@ -281,11 +328,31 @@ public final class JenkinsCompatibilitySmokeRunner {
         return new HttpTextResponse(response.statusCode(), response.body());
     }
 
-    private ImageFromDockerfile createImage(final Path pluginArtifact,
-                                            final Path passedSample,
-                                            final Path failedSample,
-                                            final Path pluginsTxt,
-                                            final Path initGroovy) {
+    private static TestHarness createTestHarness() {
+        try {
+            final Configuration config = Configuration.fromSystemProperties();
+            Files.createDirectories(config.artifactRoot());
+            final Path generatedDir = Files.createDirectories(config.artifactRoot().resolve("generated"));
+            final Path pluginArtifact = locatePluginArtifact(config.rootDir());
+            final Path passedSample = config.rootDir().resolve(PASSED_SAMPLE_RESOURCE);
+            assertFileExists(passedSample, "sample passed results");
+            final String allureCliVersion = resolveAllureCliVersion(config.rootDir());
+            final Path pluginsTxt = writeTextFile(generatedDir.resolve("plugins.txt"), buildPluginsFile());
+            final Path initGroovy = writeTextFile(generatedDir.resolve(JENKINS_INIT_FILE), buildInitScript());
+            final ImageFromDockerfile image =
+                    createImage(config, pluginArtifact, passedSample, pluginsTxt, initGroovy);
+
+            return new TestHarness(config, generatedDir, pluginArtifact, allureCliVersion, image);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Failed to initialize Jenkins compatibility test harness", exception);
+        }
+    }
+
+    private static ImageFromDockerfile createImage(final Configuration config,
+                                                   final Path pluginArtifact,
+                                                   final Path passedSample,
+                                                   final Path pluginsTxt,
+                                                   final Path initGroovy) {
         final String imageName = "allure-jenkins-compat-"
                 + Integer.toHexString(config.normalizedImageTag().hashCode()).toLowerCase(Locale.ROOT);
 
@@ -293,7 +360,6 @@ public final class JenkinsCompatibilitySmokeRunner {
                 .withFileFromPath("plugins.txt", pluginsTxt)
                 .withFileFromPath(JENKINS_INIT_FILE, initGroovy)
                 .withFileFromPath("sample-testsuite.xml", passedSample)
-                .withFileFromPath("sample-testsuite-with-failed.xml", failedSample)
                 .withFileFromPath(PLUGIN_FILE_IN_IMAGE, pluginArtifact)
                 .withDockerfileFromBuilder(builder -> builder
                         .from("jenkins/jenkins:" + config.normalizedImageTag())
@@ -307,14 +373,13 @@ public final class JenkinsCompatibilitySmokeRunner {
                         .user("root")
                         .copy(JENKINS_INIT_FILE, "/usr/share/jenkins/ref/init.groovy.d/" + JENKINS_INIT_FILE)
                         .copy("sample-testsuite.xml", SMOKE_DATA_DIR + "/sample-testsuite.xml")
-                        .copy("sample-testsuite-with-failed.xml", SMOKE_DATA_DIR + "/sample-testsuite-with-failed.xml")
                         .copy(PLUGIN_FILE_IN_IMAGE, "/usr/share/jenkins/ref/plugins/" + PLUGIN_FILE_IN_IMAGE)
                         .run("chown -R jenkins:jenkins /usr/share/jenkins/ref")
                         .user("jenkins")
                         .build());
     }
 
-    private Path locatePluginArtifact(final Path rootDir) throws IOException {
+    private static Path locatePluginArtifact(final Path rootDir) throws IOException {
         final Path targetDir = rootDir.resolve("target");
         if (Files.notExists(targetDir)) {
             throw new IllegalStateException("Plugin target directory does not exist: " + targetDir);
@@ -332,7 +397,7 @@ public final class JenkinsCompatibilitySmokeRunner {
         }
     }
 
-    private String resolveAllureCliVersion(final Path rootDir) throws IOException {
+    private static String resolveAllureCliVersion(final Path rootDir) throws IOException {
         final String override = System.getProperty("compat.allureCliVersion");
         if (override != null && !override.isBlank()) {
             return override.trim();
@@ -347,11 +412,11 @@ public final class JenkinsCompatibilitySmokeRunner {
         throw new IllegalStateException("Unable to resolve allureCommandline.version from root pom.xml");
     }
 
-    private String buildPluginsFile() {
+    private static String buildPluginsFile() {
         return REQUIRED_PLUGINS.stream().collect(Collectors.joining(System.lineSeparator())) + System.lineSeparator();
     }
 
-    private String buildInitScript() {
+    private static String buildInitScript() {
         return """
                 import hudson.security.AuthorizationStrategy
                 import hudson.security.SecurityRealm
@@ -369,7 +434,6 @@ public final class JenkinsCompatibilitySmokeRunner {
     private String buildSetupScript(final String allureCliVersion) {
         final String allureVersionLiteral = groovyStringLiteral(allureCliVersion);
         final String passedSampleLiteral = groovyStringLiteral(SMOKE_DATA_DIR + "/sample-testsuite.xml");
-        final String failedSampleLiteral = groovyStringLiteral(SMOKE_DATA_DIR + "/sample-testsuite-with-failed.xml");
 
         return """
                 import hudson.matrix.Axis
@@ -388,7 +452,6 @@ public final class JenkinsCompatibilitySmokeRunner {
                 def jenkins = Jenkins.get()
                 def allureVersion = %s
                 def passedSample = %s
-                def failedSample = %s
                 def toolDescriptor = jenkins.getDescriptorByType(AllureCommandlineInstallation.DescriptorImpl.class)
 
                 if (toolDescriptor.installations.length == 0) {
@@ -462,6 +525,7 @@ public final class JenkinsCompatibilitySmokeRunner {
                 matrix.buildersList.add(new Shell(\"\"\"#!/bin/bash -e
                 mkdir -p allure-results
                 cp ${passedSample} allure-results/sample-testsuite.xml
+                sed -i \"s#sampleTestCase#sampleTestCase-\\$items#\" allure-results/sample-testsuite.xml
                 \"\"\".stripIndent()))
                 matrix.publishersList.add(createPublisher())
                 matrix.save()
@@ -471,7 +535,6 @@ public final class JenkinsCompatibilitySmokeRunner {
                 """.formatted(
                 allureVersionLiteral,
                 passedSampleLiteral,
-                failedSampleLiteral,
                 passedSampleLiteral
         );
     }
@@ -567,6 +630,14 @@ public final class JenkinsCompatibilitySmokeRunner {
                     throw new IllegalStateException("Expected result %s but got " + buildResult)
                 }
 
+                def expectedPassed = %d
+                def expectedFailed = %d
+                if (summary.getPassedCount() != expectedPassed || summary.getFailedCount() != expectedFailed) {
+                    throw new IllegalStateException("Expected parent summary passed=" + expectedPassed
+                        + ", failed=" + expectedFailed + " but got passed=" + summary.getPassedCount()
+                        + ", failed=" + summary.getFailedCount())
+                }
+
                 def runs = build.getRuns().toList().sort { a, b -> a.getUrl() <=> b.getUrl() }
                 if (runs.size() != 2) {
                     throw new IllegalStateException("Expected 2 matrix runs but got " + runs.size())
@@ -617,81 +688,27 @@ public final class JenkinsCompatibilitySmokeRunner {
                 groovyStringLiteral(check.jobName()),
                 groovyStringLiteral(check.jobName()),
                 groovyStringLiteral(check.expectedResult()),
-                groovyStringLiteral(check.expectedResult())
+                groovyStringLiteral(check.expectedResult()),
+                check.expectedPassed(),
+                check.expectedFailed()
         );
     }
 
-    private List<SmokeCheck> buildChecks() {
-        return List.of(
-                new SmokeCheck("compat-freestyle", "SUCCESS", 1, 0, false),
-                new SmokeCheck("compat-pipeline", "SUCCESS", 1, 0, false),
-                new SmokeCheck("compat-matrix", "SUCCESS", 2, 0, true)
-        );
+    private void writeAllureEnvironment() throws IOException {
+        final Properties environment = new Properties();
+        environment.setProperty("Jenkins requested version", config.requestedVersion());
+        environment.setProperty("Jenkins Docker tag", config.normalizedImageTag());
+        environment.setProperty("Allure CLI version", allureCliVersion);
+        environment.setProperty("Plugin artifact", pluginArtifact.toString());
+        environment.setProperty("Jenkins base URL", baseUrl);
+
+        final Path resultsDir = Files.createDirectories(config.artifactRoot().resolve("allure-results"));
+        try (var writer = Files.newBufferedWriter(resultsDir.resolve("environment.properties"), StandardCharsets.UTF_8)) {
+            environment.store(writer, "Jenkins compatibility smoke");
+        }
     }
 
-    private void writeJsonReport(final List<SmokeResult> results,
-                                 final Path pluginArtifact,
-                                 final String allureCliVersion,
-                                 final Throwable failure) throws IOException {
-        final Map<String, Object> payload = new LinkedHashMap<>();
-        payload.put("requestedVersion", config.requestedVersion());
-        payload.put("jenkinsImageTag", config.normalizedImageTag());
-        payload.put("pluginArtifact", pluginArtifact.toString());
-        payload.put("allureCliVersion", allureCliVersion);
-        payload.put("results", results);
-        payload.put("failure", failure == null ? null : failure.toString());
-        OBJECT_MAPPER.writerWithDefaultPrettyPrinter()
-                .writeValue(config.artifactRoot().resolve("results.json").toFile(), payload);
-    }
-
-    private void writeSummary(final List<SmokeResult> results,
-                              final Path pluginArtifact,
-                              final String allureCliVersion,
-                              final Throwable failure,
-                              final String baseUrl) throws IOException {
-        final StringBuilder summary = new StringBuilder();
-        summary.append("# Jenkins Compatibility Smoke").append(System.lineSeparator()).append(System.lineSeparator());
-        summary.append("- Requested Jenkins version: `").append(config.requestedVersion()).append('`')
-                .append(System.lineSeparator());
-        summary.append("- Jenkins Docker tag: `").append(config.normalizedImageTag()).append('`')
-                .append(System.lineSeparator());
-        summary.append("- Plugin artifact: `").append(pluginArtifact).append('`')
-                .append(System.lineSeparator());
-        summary.append("- Allure CLI version: `").append(allureCliVersion).append('`')
-                .append(System.lineSeparator());
-        if (baseUrl != null) {
-            summary.append("- Jenkins base URL: `").append(baseUrl).append('`')
-                    .append(System.lineSeparator());
-        }
-        summary.append(System.lineSeparator());
-        summary.append("| Job | Result | Report | Passed | Failed |").append(System.lineSeparator());
-        summary.append("| --- | --- | --- | --- | --- |").append(System.lineSeparator());
-        for (SmokeResult result : results) {
-            summary.append("| ")
-                    .append(result.jobName())
-                    .append(" | ")
-                    .append(result.result())
-                    .append(" | ")
-                    .append(result.reportStatusCode())
-                    .append(" | ")
-                    .append(result.summary().passed())
-                    .append(" | ")
-                    .append(result.summary().failed())
-                    .append(" |")
-                    .append(System.lineSeparator());
-        }
-        if (failure != null) {
-            summary.append(System.lineSeparator())
-                    .append("## Failure").append(System.lineSeparator()).append(System.lineSeparator())
-                    .append("```").append(System.lineSeparator())
-                    .append(failure).append(System.lineSeparator())
-                    .append("```").append(System.lineSeparator());
-        }
-
-        writeTextFile(config.artifactRoot().resolve("summary.md"), summary.toString());
-    }
-
-    private Path writeTextFile(final Path path, final String content) throws IOException {
+    private static Path writeTextFile(final Path path, final String content) throws IOException {
         Files.createDirectories(path.getParent());
         Files.writeString(path, content, StandardCharsets.UTF_8);
         return path;
@@ -756,23 +773,19 @@ public final class JenkinsCompatibilitySmokeRunner {
                               boolean matrix) {
     }
 
-    private record JobSummary(int passed, int failed, int broken, int skipped, int unknown) {
-    }
+    private record TestHarness(Configuration config,
+                               Path generatedDir,
+                               Path pluginArtifact,
+                               String allureCliVersion,
+                               ImageFromDockerfile image) {
 
-    private record ChildBuildResult(String url,
-                                    String result,
-                                    String actionUrlName,
-                                    JobSummary summary) {
-    }
-
-    private record SmokeResult(String jobName,
-                               String result,
-                               String buildUrl,
-                               String reportUrl,
-                               int reportStatusCode,
-                               String consoleUrl,
-                               JobSummary summary,
-                               List<ChildBuildResult> children) {
+        private GenericContainer<?> createContainer() {
+            return new GenericContainer<>(image)
+                    .withExposedPorts(8080)
+                    .withEnv("JAVA_OPTS", "-Djenkins.install.runSetupWizard=false")
+                    .waitingFor(Wait.forLogMessage(".*Jenkins is fully up and running.*\\n", 1))
+                    .withStartupTimeout(STARTUP_TIMEOUT);
+        }
     }
 
     private record HttpTextResponse(int statusCode, String body) {

--- a/compat/jenkins-smoke/src/test/java/org/allurereport/jenkins/compat/JenkinsCompatibilitySmokeTest.java
+++ b/compat/jenkins-smoke/src/test/java/org/allurereport/jenkins/compat/JenkinsCompatibilitySmokeTest.java
@@ -44,9 +44,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -126,7 +129,8 @@ class JenkinsCompatibilitySmokeTest {
     @AfterAll
     void tearDown() throws Exception {
         final String logs = JENKINS.isRunning() ? JENKINS.getLogs() : "Jenkins container did not start.";
-        writeTextFile(config.artifactRoot().resolve("jenkins.log"), logs);
+        final Path jenkinsLog = writeTextFile(config.artifactRoot().resolve("jenkins.log"), logs);
+        writeGlobalAttachments(jenkinsLog);
     }
 
     @Test
@@ -706,6 +710,64 @@ class JenkinsCompatibilitySmokeTest {
         try (var writer = Files.newBufferedWriter(resultsDir.resolve("environment.properties"), StandardCharsets.UTF_8)) {
             environment.store(writer, "Jenkins compatibility smoke");
         }
+    }
+
+    private void writeGlobalAttachments(final Path jenkinsLog) throws IOException {
+        final Path resultsDir = Files.createDirectories(config.artifactRoot().resolve("allure-results"));
+        final List<Map<String, String>> attachments = new ArrayList<>();
+
+        addGlobalAttachment(resultsDir, attachments, jenkinsLog, "jenkins.log", "text/plain");
+        addGlobalAttachment(
+                resultsDir,
+                attachments,
+                generatedDir.resolve(JENKINS_INIT_FILE),
+                JENKINS_INIT_FILE,
+                "text/x-groovy"
+        );
+        addGlobalAttachment(
+                resultsDir,
+                attachments,
+                generatedDir.resolve("setup.groovy"),
+                "setup.groovy",
+                "text/x-groovy"
+        );
+        addGlobalAttachment(
+                resultsDir,
+                attachments,
+                generatedDir.resolve("plugins.txt"),
+                "plugins.txt",
+                "text/plain"
+        );
+
+        final Map<String, Object> globals = Map.of(
+                "attachments", attachments,
+                "errors", List.of()
+        );
+        writeTextFile(
+                resultsDir.resolve(UUID.randomUUID() + "-globals.json"),
+                OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(globals)
+        );
+    }
+
+    private static void addGlobalAttachment(final Path resultsDir,
+                                            final List<Map<String, String>> attachments,
+                                            final Path artifact,
+                                            final String name,
+                                            final String type) throws IOException {
+        if (Files.notExists(artifact)) {
+            return;
+        }
+
+        final String artifactFileName = artifact.getFileName().toString();
+        final int extensionIndex = artifactFileName.lastIndexOf('.');
+        final String extension = extensionIndex >= 0 ? artifactFileName.substring(extensionIndex) : "";
+        final String source = UUID.randomUUID() + "-attachment" + extension;
+        Files.copy(artifact, resultsDir.resolve(source));
+        attachments.add(Map.of(
+                "name", name,
+                "type", type,
+                "source", source
+        ));
     }
 
     private static Path writeTextFile(final Path path, final String content) throws IOException {

--- a/docs/allure-agent-mode.md
+++ b/docs/allure-agent-mode.md
@@ -1,0 +1,162 @@
+# Allure Agent Mode
+
+Use Allure agent mode to design, review, validate, debug, and enrich tests in this project.
+
+Before authoring or materially changing a test, invoke the `$allure-agent-mode` skill and read its `references/test-design.md`. If the skill is unavailable, use the test-design floor below and keep conclusions conservative.
+
+## Why Agent Mode
+
+A test run is an instrument, not a pass/fail to scrape. `allure agent` preserves a reviewable account of the tests, failures, runtime artifacts, and automated findings. Give every result-informing run a `--goal`, read the printed summary, and then inspect the generated agent output beginning with its `AGENTS.md` and `index.md`.
+
+Do not reduce a run to console fragments with `tail`, `grep`, `head`, or `/dev/null`. The console is a status signal; the agent output is the evidence.
+
+## Local Capability Snapshot
+
+- Allure wrapper: `npx --yes allure@3`
+- Capability snapshot last checked: 2026-08-26
+- Refresh with: `npx --yes allure@3 --version`, `npx --yes allure@3 agent --help`, `npx --yes allure@3 agent capabilities --json`, and `npx --yes allure@3 agent -h=1`
+- Agent execution: supported with `--goal`, `--output`, `--results-dir`, expectations, environments, selection, and reruns
+- Human report modes: `--report auto|off|awesome|config`
+- Latest/state recovery: `agent latest`, `agent state-dir`, and `agent query`
+- Selection/rerun: `agent select`, `--rerun-latest`, and `--rerun-from <output>` with `review`, `failed`, `unsuccessful`, or `all` presets
+- Existing results: `agent inspect <allure-results-dir-or-glob>`
+- CI dumps: `agent inspect --dump <archive-or-glob>`; repeat `--dump` to combine archives
+
+Node.js and npm are required for the project wrapper. A compatible global `allure` command may be used interactively, but committed examples use the same `npx` wrapper as CI.
+The `allure@3` selector intentionally floats to the newest Allure 3 release published to npm; workflows do not pin a minor or patch version.
+
+## Test Surfaces And Results
+
+| Surface | Runner | Test root | Results | Prerequisites |
+| --- | --- | --- | --- | --- |
+| Regular unit tests | Maven Surefire + JUnit 4 | `src/test/java/**/*Test.java` | `target/allure-results` | Java and Maven wrapper |
+| Regular integration tests | Maven Failsafe + JUnit 4 | `src/test/java/**/*IT.java` | `target/allure-results` | Jenkins test harness; the build downloads an Allure commandline fixture |
+| Jenkins compatibility smoke | Maven Surefire + JUnit 5/Testcontainers | `compat/jenkins-smoke/src/test/java` | `compat-artifacts/<jenkins-version>/allure-results` | Docker, Java 17, and a built plugin HPI |
+
+The regular test adapter is configured in `pom.xml`; its stable result path is configured in `src/test/resources/allure.properties`. The compatibility runner has its own adapter and result path in `compat/jenkins-smoke/pom.xml`.
+
+The Jenkins plugin harness also executes generated validation tests under `org.jvnet.hudson.test`. They are part of the regular Maven signal even though they are not declared with `@Test` in this repository. Some integration tests create nested `allure-results` fixtures containing deliberately failed sample data, so regular agent and CI runs must pass `--results-dir target/allure-results` instead of using unrestricted discovery.
+
+The root suite supports Maven's `-Dtest=ClassName` or `-Dtest=ClassName#method` selectors for Surefire and `-Dit.test=ClassName` for Failsafe. The compatibility runner supports `-Dtest=JenkinsCompatibilitySmokeTest` and standard JUnit 5 method selectors through Surefire.
+
+## Run Profiles
+
+Use the CLI-provided temporary agent output by default.
+
+### Focused unit test
+
+```bash
+npx --yes allure@3 agent \
+  --results-dir target/allure-results \
+  --goal "Confirm the selected unit-test behavior and preserve reviewable evidence" \
+  -- ./mvnw -B -ntp -Dtest=Allure3ConfigTest test
+```
+
+Replace the selector with the class or method relevant to the change.
+
+### Full regular suite
+
+```bash
+npx --yes allure@3 agent \
+  --results-dir target/allure-results \
+  --goal "Confirm the complete regular unit and integration suite" \
+  -- ./mvnw -B -ntp verify
+```
+
+`package` does not reach Maven's Failsafe integration-test and verify phases. Use `verify` when the conclusion is meant to cover all regular tests.
+
+### Compatibility smoke
+
+Build the HPI first, then follow `compat/README.md` for the version-specific Maven properties. Wrap only the compatibility test command:
+
+```bash
+npx --yes allure@3 agent \
+  --results-dir "$PWD/compat-artifacts/2.462.1/allure-results" \
+  --goal "Confirm Jenkins compatibility for the selected Jenkins version" \
+  -- ./mvnw -B -e -ntp -f compat/jenkins-smoke/pom.xml \
+    -Dcompat.rootDir="$PWD" \
+    -Dcompat.version=2.462.1 \
+    -Dcompat.artifactRoot="$PWD/compat-artifacts/2.462.1" \
+    test
+```
+
+Compatibility coverage is a separate Docker-backed signal; a regular `verify` run does not include it.
+
+## Core Review Loop
+
+1. State the intended behavior, scope, and confidence limit in `--goal`.
+2. Decide whether a small fresh expectation would protect the conclusion.
+3. Use `--report off` for intermediate private runs and `--report auto` or `awesome` for the final reviewable run.
+4. Run the narrowest command that supports the conclusion.
+5. Print and open the output directory's `index.md`.
+6. Read its `AGENTS.md`, `manifest/run.json`, `manifest/test-events.jsonl`, `manifest/tests.jsonl`, `manifest/findings.jsonl`, and relevant per-test Markdown before inspecting source.
+7. If expectations were used, inspect `manifest/expected.json` and confirm the contracted scope resolved correctly.
+8. If a runner-visible failure is absent from `manifest/tests.jsonl`, inspect `artifacts/global/` for stdout/stderr and describe the review as partial.
+9. Enrich weak evidence only at meaningful behavior or helper boundaries, then rerun with fresh output.
+
+## Expectations
+
+Inline controls are supported for exact test count, full names and prefixes, labels, environment, minimum steps or attachments, and attachment name/content type. Confirm exact syntax with `npx --yes allure@3 agent --help` before use.
+
+Use the smallest expectation that protects a real claim. Do not add step or attachment expectations merely to force decorative evidence. Every expectation run must use fresh expectations for its exact intended scope; never reuse expectation state across unrelated runs.
+
+When no stable count or identity is known, omit expectations, review the observed scope from the manifests, and state that scope checking was observational.
+
+## Failure Triage And Reruns
+
+Read the failing per-test evidence and findings before editing. Classify the failure as a product defect, stale or wrong expectation, fixture/environment problem, or flake. Do not weaken assertions or hide the test to get a green run.
+
+For reruns, use the captured test plan instead of reconstructing runner selectors:
+
+```bash
+npx --yes allure@3 agent --rerun-latest --rerun-preset unsuccessful \
+  --goal "Recheck only unsuccessful tests after the fix" \
+  -- ./mvnw -B -ntp verify
+```
+
+## Inspecting CI Evidence
+
+The build workflow retains `allure-results-build` as an Allure dump and generates the `allure-report` artifact in an always-run report job. When the `ALLURE_SERVICE_TOKEN` GitHub Actions secret is available, the same report generation command also publishes the report to Allure Service. Fork pull requests, where repository secrets are unavailable, still retain the downloadable dump and report artifacts. Compatibility jobs retain `compat-<version>-allure3-dump`.
+
+Inspect downloaded artifacts before trying to reproduce a CI-only failure:
+
+```bash
+npx --yes allure@3 agent inspect \
+  --goal "Review the downloaded CI execution and identify actionable failures" \
+  --dump 'allure-results-*.zip'
+```
+
+Pass compatibility archives with another `--dump`. Use `--report awesome` for a forced single-file report when needed.
+
+## Output And Concurrency
+
+Agent output, `target/allure-results`, compatibility results, CI dumps, and generated reports are separate artifacts.
+
+- Default agent output is a CLI-managed temporary directory; recover it with `npx --yes allure@3 agent latest`.
+- An explicit `--output <dir>` is caller-managed and must be removed or archived when no longer needed.
+- Concurrent runs must each use a unique explicit `--output` directory. Never share output paths or expectation state; the default temporary output is unsafe for parallel runs because a newer run can replace the previous default.
+- Agent mode can discover newly emitted directories named `allure-results`, but regular project runs must override discovery with `--results-dir target/allure-results` so temporary test fixtures are not reported as suite results. Clearing the canonical result directory is not required, though `clean` may still be useful for an isolated Maven build.
+- For a final run, read `manifest/human-report.json`. If its status is `generated`, resolve its path against the agent output directory and share that absolute report link.
+
+## Test-Design Floor
+
+- Tests are behavior contracts. Do not delete, weaken, invert, skip, mute, or quarantine coverage merely to make a run pass.
+- A regression test should fail for the intended defect before the fix and pass afterward, or the handoff must explain why pre-fix reproduction was impossible.
+- Prefer explicit, independently runnable tests and precise observable assertions over loops, factories, conditional registration, or broad existence checks.
+- Do not hide missing prerequisites behind early returns or runtime `if` branches. Use JUnit's visible `@Ignore` or `Assume` mechanics with a clear reason when suppression is legitimate.
+- Current known suppression: `ReportGenerateIT.shouldFailBuildIfNoResultsFound` is explicitly ignored because of the Windows commandline exit-code behavior. There is no broader documented quarantine policy.
+
+## Evidence Conventions
+
+The adapters always provide test identity, status, timing, suite/package data, and failure details. Current root tests do not define a general metadata or attachment taxonomy; do not invent one.
+
+When extra evidence is necessary:
+
+- keep descriptions, labels, links, parameters, and intent-defining step names inline with the test
+- use steps for meaningful setup, actions, external calls, and assertion phases
+- attach current-execution artifacts such as generated files, Jenkins logs, command output, or fixture state only when they explain behavior or failure
+- redact secrets while preserving the artifact's useful structure
+- prefer Allure integrations and stable helper boundaries over wrapping every test line
+- avoid placeholder steps, static success messages, stale files, and a single ceremonial step around the whole test
+
+Accept a run only when observed scope matches the claim, coverage remains meaningful, evidence explains the result, execution limits are explicit, and no high-confidence placeholder or no-op evidence finding remains.

--- a/docs/allure-agent-mode.md
+++ b/docs/allure-agent-mode.md
@@ -116,7 +116,7 @@ npx --yes allure@3 agent --rerun-latest --rerun-preset unsuccessful \
 
 ## Inspecting CI Evidence
 
-The build workflow retains `allure-results-build` as an Allure dump and generates the `allure-report` artifact in an always-run report job. When the `ALLURE_SERVICE_TOKEN` GitHub Actions secret is available, the same report generation command also publishes the report to Allure Service. Fork pull requests, where repository secrets are unavailable, still retain the downloadable dump and report artifacts. Compatibility jobs retain `compat-<version>-allure3-dump`.
+The build workflow retains `allure-results-build` as an Allure dump and generates the `allure-report` artifact in an always-run report job. Report plugins, grouping, and conditional Allure Service access are configured in `allurerc.mjs`. When the `ALLURE_SERVICE_TOKEN` GitHub Actions secret is available, the same report generation command also publishes the report to Allure Service. Fork pull requests, where repository secrets are unavailable, still retain the downloadable dump and report artifacts. Compatibility jobs retain `compat-<version>-allure3-dump`.
 
 Inspect downloaded artifacts before trying to reproduce a CI-only failure:
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
   </issueManagement>
 
   <properties>
+    <allure.version>2.35.3</allure.version>
     <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
     <spotless.skip>false</spotless.skip>
     <spotless.check.skip>false</spotless.check.skip>
@@ -67,6 +68,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>io.qameta.allure</groupId>
+        <artifactId>allure-bom</artifactId>
+        <version>${allure.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
@@ -153,6 +161,11 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.qameta.allure</groupId>
+      <artifactId>allure-junit-platform</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/resources/allure.properties
+++ b/src/test/resources/allure.properties
@@ -1,0 +1,1 @@
+allure.results.directory=target/allure-results


### PR DESCRIPTION
Adds a Docker-backed compatibility suite that installs the plugin into a real Jenkins controller and verifies Allure report generation for Freestyle, Pipeline, and Matrix jobs. Pull requests are checked against Jenkins 2.462.1 by default, while manual runs can target other Jenkins versions or Docker tags.
