### PR TITLE
Fix severe report browsing latency with remote ArtifactManager (S3/Azure)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project
+
+Jenkins plugin (`org.allurereport.jenkins:allure-jenkins-plugin`, `hpi` packaging) that publishes Allure test reports as a post-build action and serves them in the Jenkins UI. Java 11, Maven, Jenkins baseline `2.462`.
+
+## Build & test commands
+
+Uses the Maven wrapper — do not invoke a system `mvn`.
+
+```bash
+./mvnw package                                    # full build with unit tests + spotless/checkstyle/pmd/spotbugs (bound to `validate` phase)
+./mvnw test                                       # unit tests only
+./mvnw verify                                     # runs integration tests (*IT classes via maven-failsafe-plugin)
+./mvnw test -Dtest=ReportBuilderTest              # single unit test class
+./mvnw test -Dtest=ReportBuilderTest#methodName   # single unit test method
+./mvnw verify -Dit.test=AllureReportBuildActionIT # single integration test
+./mvnw hpi:run                                    # launch Jenkins at localhost:8080/jenkins with the plugin loaded (dev loop)
+./mvnw spotless:apply                             # auto-format Java/XML/properties
+```
+
+Integration tests download `allure-commandline` (version pinned in `pom.xml` as `allureCommandline.version`) into `target/resources/test/` during the `pre-integration-test` phase — the first `verify` after a clean needs network access.
+
+Spotless is configured with `ratchetFrom=origin/main`, so formatting checks only apply to files changed relative to `main`. Checkstyle/PMD/SpotBugs run on every build at the `validate` phase and can fail `./mvnw package`.
+
+## Architecture — the big picture
+
+### Post-build flow (writing a report)
+
+`AllureReportPublisher#perform` (`src/main/java/org/allurereport/jenkins/AllureReportPublisher.java`) is the entry point. It:
+
+1. Resolves result directories from globs via `FindByGlob` (a `MasterToSlaveFileCallable`).
+2. Enriches `allure-results/` on the agent with executor/environment/testrun metadata and copies history from the previous build (via `callables/Add*Info` and `AllureReportArchiveSource`).
+3. Picks the CLI (`AllureCommandlineInstallation` for Allure 2, `Allure3Installation` for Allure 3 — `getAllureVersion()` gates which one) and invokes `ReportBuilder#build`, which shells out to `allure generate`.
+4. **Archives the generated report into `allure-report.zip` via `AllureReportArchive` (agent-side `MasterToSlaveFileCallable` using `TrueZipArchiver`), uploads it through `run.pickArtifactManager().archive(...)`, and then deletes both the local zip and the unpacked directory.** This is the source of truth now — there is no persistent unpacked report directory. This was introduced in PR #433 (`dcbfc95 Remove unzipped report dir`) to fix the "disk consumed twice" regression (issue #426).
+5. Attaches an `AllureReportBuildAction` to the `Run` and applies threshold-based result policies.
+
+Matrix support: `AllureReportPublisher` is a `MatrixAggregatable`. Per-configuration results are copied to the parent workspace (`copyResultsToParentIfNeeded`), then aggregated in `MatrixAggregator#endBuild`.
+
+### Serving the report (reading)
+
+`AllureReportBuildAction#doDynamic` is the Stapler entry point for `/<job>/<build>/allure/...`. It resolves a report source via `AllureReportArchiveSourceFactory.forRun(run)` and returns one of two inner `HttpResponse` handlers:
+
+- `ArchiveReportBrowser` — wraps an `AllureReportArchiveSource` and streams individual entries out of the zip on demand. Used for both locally-stored zips and remote artifact managers (S3, Azure, etc.).
+- `DirectoryReportBrowser` — legacy path that serves from an unpacked directory under `run.getRootDir()`; only reached if the archive isn't present.
+
+**`AllureReportArchiveSource` abstraction** (`src/main/java/org/allurereport/jenkins/utils/`) is the key architectural piece for understanding report serving:
+
+- `LocalFileArchiveSource` — opens `<artifactsDir>/allure-report.zip` with `java.util.zip.ZipFile` (random access, fast entry lookup).
+- `ArtifactManagerArchiveSource` — goes through `run.getArtifactManager().root()` / `VirtualFile`. If the zip lives on S3/Azure, `VirtualFile.open()` returns a stream from remote storage, and entries are located via `ZipEntryInputStream` which **linearly scans a `ZipInputStream`** (no central-directory random access over HTTP). This is the reason remote-stored reports are slow: every click re-opens the remote stream and scans from the start until the target entry is found. PR #446 (`f60fcb3 Fix Allure report browsing with S3`) is what introduced this behavior — before, S3-stored archives weren't browsable at all.
+- `FallbackArchiveSource` — tries local first, falls back to artifact manager. This is what `AllureReportArchiveSourceFactory.forRun()` returns.
+
+History propagation between builds also goes through `AllureReportArchiveSource` — `FilePathUtils#getPreviousRunWithHistory` and `copyHistoryToResultsPaths` read `history/*.json` entries out of the previous build's archive, so history works the same whether the archive is local or remote.
+
+### Configuration & UI
+
+- Jelly views for each `Action` live under `src/main/resources/org/allurereport/jenkins/<ActionClassName>/`.
+- `AllureReportPublisherDescriptor` owns global configuration (commandline installations, properties). The legacy `AllureBuildAction` (deprecated, `DirectoryBrowserSupport`-based) is retained only for deserializing old builds via `AllureXStreamAliases`.
+- `dsl/` package integrates with the `job-dsl` plugin; `config/` holds POJOs (`AllureReportConfig`, `ResultsConfig`, `ReportBuildPolicy`, `ResultPolicy`).
+- Allure 3 vs Allure 2: `isAllure3()` branches throughout. Allure 3 is Node-based (no JDK configuration, different summary paths under `awesome/widgets/summary.json`), Allure 2 is Java-based.
+
+## Investigation context (from `../instructions.md`)
+
+This repo was cloned to investigate performance of Allure report browsing with the S3 Artifact Manager plugin after upgrading to v2.35.2. Key historical points:
+
+- **Before ~v2.34**: the generated Allure report directory lived unpacked under `<run>/archive/allure-report/` and was served with `DirectoryBrowserSupport` (old `AllureBuildAction`, still present as deprecated). No zip existed.
+- **v2.34.0**: added zipping of the report for artifact storage but **did not remove the unpacked copy** — hence issue #426 (disk used twice).
+- **v2.35.0 (PR #433)**: removes the unpacked directory after archiving; introduces the `AllureReportArchiveSource` abstraction so the UI reads entries out of the zip on demand.
+- **v2.35.1 (PR #446)**: fixes browsing when the zip is stored via an artifact manager (e.g. S3) — adds `ArtifactManagerArchiveSource` + `ZipEntryInputStream`. **This is the path that is slow over S3**: linear scan of a remote `ZipInputStream` per request.
+
+When reasoning about performance: the bottleneck is the linear scan in `ZipEntryInputStream.open()` combined with the fact that `ArchiveReportBrowser#generateResponse` opens a fresh stream per request via `AllureReportArchiveSourceFactory.forRun(run)` (no caching of central directory, no range-read optimization).

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>org.allurereport.jenkins</groupId>
   <artifactId>allure-jenkins-plugin</artifactId>
-  <version>2.36-SNAPSHOT</version>
+  <version>2.35.2.0</version>
   <packaging>hpi</packaging>
 
   <name>Allure Jenkins Plugin</name>

--- a/src/main/java/org/allurereport/jenkins/AllureReportBuildAction.java
+++ b/src/main/java/org/allurereport/jenkins/AllureReportBuildAction.java
@@ -67,11 +67,7 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
 
     private static final String ALLURE_REPORT = "allure-report";
     private static final String CACHE_CONTROL = "Cache-Control";
-    private static final String CACHE_CONTROL_NO_CACHE = "no-cache, no-store, must-revalidate";
-    private static final String CACHE_CONTROL_POST_CHECK = "post-check=0, pre-check=0";
-    private static final String HEADER_PRAGMA = "Pragma";
-    private static final String HEADER_PRAGMA_NO_CACHE = "no-cache";
-    private static final String HEADER_EXPIRES = "Expires";
+    private static final String CACHE_CONTROL_IMMUTABLE = "public, max-age=31536000, immutable";
     private static final String HASH_404 = "#404";
     private static final String WAS_ATTACHED_TO_BOTH = "%s was attached to both %s and %s";
     private static final String HEADER_CONTENT_SECURITY_POLICY = "Content-Security-Policy";
@@ -79,7 +75,7 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
     private static final String HEADER_NOSNIFF = "nosniff";
     private static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
     private static final String INDEX_HTML = "index.html";
-    private static final String ALLURE_REPORT_ZIP = "allure-report.zip";
+
     private static final String SLASH = "/";
     private static final String PATH_TRAVERSAL = "..";
     private static final String ILLEGAL_PATH = "Illegal path";
@@ -489,10 +485,7 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
 
                 rsp.setHeader(HEADER_CONTENT_SECURITY_POLICY, "");
                 rsp.setHeader(HEADER_X_CONTENT_TYPE_OPTIONS, HEADER_NOSNIFF);
-                rsp.setHeader(CACHE_CONTROL, CACHE_CONTROL_NO_CACHE);
-                rsp.addHeader(CACHE_CONTROL, CACHE_CONTROL_POST_CHECK);
-                rsp.setHeader(HEADER_PRAGMA, HEADER_PRAGMA_NO_CACHE);
-                rsp.setDateHeader(HEADER_EXPIRES, 0);
+                rsp.setHeader(CACHE_CONTROL, CACHE_CONTROL_IMMUTABLE);
 
                 final String rest = normalizeRestOfPath(req, rsp);
                 if (rest == null) {

--- a/src/main/java/org/allurereport/jenkins/AllureReportBuildAction.java
+++ b/src/main/java/org/allurereport/jenkins/AllureReportBuildAction.java
@@ -67,7 +67,11 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
 
     private static final String ALLURE_REPORT = "allure-report";
     private static final String CACHE_CONTROL = "Cache-Control";
+    // Content served under a numbered build URL (/job/x/42/allure/...) is fixed forever.
     private static final String CACHE_CONTROL_IMMUTABLE = "public, max-age=31536000, immutable";
+    // The project-level permalink (/job/x/allure/...) is backed by getLastCompletedBuild(),
+    // so the same URL serves new content each build — it must be revalidated, never cached as immutable.
+    private static final String CACHE_CONTROL_REVALIDATE = "no-cache";
     private static final String HASH_404 = "#404";
     private static final String WAS_ATTACHED_TO_BOTH = "%s was attached to both %s and %s";
     private static final String HEADER_CONTENT_SECURITY_POLICY = "Content-Security-Policy";
@@ -278,7 +282,8 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
 
         final AllureReportArchiveSource archiveSource = AllureReportArchiveSourceFactory.forRun(run);
         if (archiveSource.exists()) {
-            return new ArchiveReportBrowser(archiveSource, reportDirName, reportDirectoryUnderBuild.getRemote());
+            return new ArchiveReportBrowser(
+                    archiveSource, reportDirName, reportDirectoryUnderBuild.getRemote(), isBuildScopedUrl(request));
         }
         archiveSource.close();
 
@@ -292,6 +297,21 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
                         + reportDirectoryUnderBuild.getRemote() + "' exists."
         );
         return null;
+    }
+
+    /**
+     * Whether this request reached the action through a concrete, numbered build URL
+     * ({@code /job/x/42/allure/...}) rather than the moving project permalink
+     * ({@code /job/x/allure/...}, backed by {@link Job#getLastCompletedBuild()}).
+     *
+     * <p>Build-scoped URLs address content that is fixed forever and may be served
+     * {@code immutable}; the permalink alias serves different content each build and
+     * must be revalidated. When accessed via a numbered URL Stapler traverses the
+     * {@link Run}, so it appears as an ancestor; the permalink resolves the action via
+     * {@link AllureReportProjectAction#getTarget()} without a {@link Run} ancestor.
+     */
+    private static boolean isBuildScopedUrl(final StaplerRequest request) {
+        return request.findAncestorObject(Run.class) != null;
     }
 
     @SuppressWarnings("unused")
@@ -459,13 +479,16 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
         private final AllureReportArchiveSource source;
         private final String reportPath;
         private final String reportDirectoryPath;
+        private final boolean immutable;
 
         ArchiveReportBrowser(final AllureReportArchiveSource source,
                              final String reportPath,
-                             final String reportDirectoryPath) {
+                             final String reportDirectoryPath,
+                             final boolean immutable) {
             this.source = source;
             this.reportPath = reportPath;
             this.reportDirectoryPath = reportDirectoryPath;
+            this.immutable = immutable;
         }
 
         @Override
@@ -485,7 +508,7 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
 
                 rsp.setHeader(HEADER_CONTENT_SECURITY_POLICY, "");
                 rsp.setHeader(HEADER_X_CONTENT_TYPE_OPTIONS, HEADER_NOSNIFF);
-                rsp.setHeader(CACHE_CONTROL, CACHE_CONTROL_IMMUTABLE);
+                rsp.setHeader(CACHE_CONTROL, immutable ? CACHE_CONTROL_IMMUTABLE : CACHE_CONTROL_REVALIDATE);
 
                 final String rest = normalizeRestOfPath(req, rsp);
                 if (rest == null) {

--- a/src/main/java/org/allurereport/jenkins/AllureReportPublisherDescriptor.java
+++ b/src/main/java/org/allurereport/jenkins/AllureReportPublisherDescriptor.java
@@ -61,8 +61,11 @@ public class AllureReportPublisherDescriptor extends BuildStepDescriptor<Publish
     private static final String PROPERTIES = "properties";
     private static final String NEWLINE = "\n";
     private static final int SINGLE_INSTALLATION = 1;
+    private static final long DEFAULT_LOCAL_CACHE_THRESHOLD_MB = 100;
     private final Object quickSetupLock = new Object();
     private List<PropertyConfig> properties;
+    private boolean localCacheEnabled;
+    private long localCacheThresholdMb = DEFAULT_LOCAL_CACHE_THRESHOLD_MB;
 
     public AllureReportPublisherDescriptor() {
         super(AllureReportPublisher.class);
@@ -82,6 +85,22 @@ public class AllureReportPublisherDescriptor extends BuildStepDescriptor<Publish
 
     public void setProperties(final List<PropertyConfig> properties) {
         this.properties = properties;
+    }
+
+    public boolean isLocalCacheEnabled() {
+        return localCacheEnabled;
+    }
+
+    public void setLocalCacheEnabled(final boolean localCacheEnabled) {
+        this.localCacheEnabled = localCacheEnabled;
+    }
+
+    public long getLocalCacheThresholdMb() {
+        return localCacheThresholdMb;
+    }
+
+    public void setLocalCacheThresholdMb(final long localCacheThresholdMb) {
+        this.localCacheThresholdMb = localCacheThresholdMb;
     }
 
     @Override
@@ -121,8 +140,10 @@ public class AllureReportPublisherDescriptor extends BuildStepDescriptor<Publish
                 final List<PropertyConfig> properties = mapper.readValue(jsonProperties,
                     new TypeReference<List<PropertyConfig>>() { });
                 setProperties(properties);
-                save();
             }
+            localCacheEnabled = json.optBoolean("localCacheEnabled", false);
+            localCacheThresholdMb = json.optLong("localCacheThresholdMb", DEFAULT_LOCAL_CACHE_THRESHOLD_MB);
+            save();
         } catch (IOException e) {
             return false;
         }

--- a/src/main/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSource.java
+++ b/src/main/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSource.java
@@ -80,6 +80,7 @@ public final class ArtifactManagerArchiveSource implements AllureReportArchiveSo
     }
 
     @Override
+    @SuppressWarnings("PMD.CloseResource") // zip is the cached, long-lived localZipFile, closed in close()
     public InputStream openEntry(final String entryPath) throws IOException, InterruptedException {
         final String runId = run.getExternalizableId();
 
@@ -121,6 +122,7 @@ public final class ArtifactManagerArchiveSource implements AllureReportArchiveSo
     }
 
     @Override
+    @SuppressWarnings("PMD.CloseResource") // zip is the cached, long-lived localZipFile, closed in close()
     public List<String> listEntries(final String prefix) throws IOException, InterruptedException {
         final VirtualFile root = getArtifactRoot();
         if (root == null) {

--- a/src/main/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSource.java
+++ b/src/main/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSource.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.zip.ZipEntry;
@@ -49,6 +50,16 @@ import java.util.zip.ZipFile;
 public final class ArtifactManagerArchiveSource implements AllureReportArchiveSource {
 
     private static final Logger LOGGER = Logger.getLogger(ArtifactManagerArchiveSource.class.getName());
+
+    /**
+     * Guards the download-and-open step against concurrent first views of the same build.
+     * A fresh {@link ArtifactManagerArchiveSource} is created per HTTP request, but browsers
+     * fire many parallel asset requests, so several instances can race to materialize the same
+     * {@code <artifactsDir>/allure-report.zip}. Keyed by the destination path so unrelated builds
+     * never contend; entries are only ever added, which is fine for the small, bounded set of
+     * builds browsed in a session.
+     */
+    private static final ConcurrentHashMap<Path, Object> DOWNLOAD_LOCKS = new ConcurrentHashMap<>();
 
     private final Run<?, ?> run;
     private VirtualFile artifactRoot;
@@ -169,6 +180,8 @@ public final class ArtifactManagerArchiveSource implements AllureReportArchiveSo
     @SuppressWarnings("PMD.CloseResource")
     private ZipFile getOrDownloadToArtifactsDir(final VirtualFile zipBlob)
             throws IOException, InterruptedException {
+        // This instance is confined to a single request, but multiple instances (one per
+        // parallel asset request) can target the same file; serialize per destination path.
         if (localZipFile != null) {
             return localZipFile;
         }
@@ -176,25 +189,30 @@ public final class ArtifactManagerArchiveSource implements AllureReportArchiveSo
         final Path localPath = run.getArtifactsDir().toPath()
                 .resolve(AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP);
 
-        if (Files.exists(localPath)) {
-            LOGGER.log(Level.FINE, "Using existing local copy at {0}", localPath);
+        synchronized (DOWNLOAD_LOCKS.computeIfAbsent(localPath.toAbsolutePath(), k -> new Object())) {
+            if (localZipFile != null) {
+                return localZipFile;
+            }
+            if (Files.exists(localPath)) {
+                LOGGER.log(Level.FINE, "Using existing local copy at {0}", localPath);
+                localZipFile = new ZipFile(localPath.toFile());
+                return localZipFile;
+            }
+
+            LOGGER.log(Level.INFO, "Downloading allure-report.zip from remote storage to {0} for run {1}",
+                    new Object[]{localPath, run.getExternalizableId()});
+
+            Files.createDirectories(localPath.getParent());
+            final Path tmpFile = Files.createTempFile(localPath.getParent(), "allure-report-", ".zip.tmp");
+            try (InputStream is = zipBlob.open()) {
+                Files.copy(is, tmpFile, StandardCopyOption.REPLACE_EXISTING);
+            }
+            Files.move(tmpFile, localPath, StandardCopyOption.REPLACE_EXISTING,
+                    StandardCopyOption.ATOMIC_MOVE);
+
             localZipFile = new ZipFile(localPath.toFile());
             return localZipFile;
         }
-
-        LOGGER.log(Level.INFO, "Downloading allure-report.zip from remote storage to {0} for run {1}",
-                new Object[]{localPath, run.getExternalizableId()});
-
-        Files.createDirectories(localPath.getParent());
-        final Path tmpFile = Files.createTempFile(localPath.getParent(), "allure-report-", ".zip.tmp");
-        try (InputStream is = zipBlob.open()) {
-            Files.copy(is, tmpFile, StandardCopyOption.REPLACE_EXISTING);
-        }
-        Files.move(tmpFile, localPath, StandardCopyOption.REPLACE_EXISTING,
-                StandardCopyOption.ATOMIC_MOVE);
-
-        localZipFile = new ZipFile(localPath.toFile());
-        return localZipFile;
     }
 
     private VirtualFile getArtifactRoot() {

--- a/src/main/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSource.java
+++ b/src/main/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSource.java
@@ -17,30 +17,42 @@ package org.allurereport.jenkins.utils;
 
 import hudson.model.Run;
 import jenkins.model.ArtifactManager;
+import jenkins.model.Jenkins;
 import jenkins.util.VirtualFile;
+import org.allurereport.jenkins.AllureReportPublisherDescriptor;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 /**
- * {@link AllureReportArchiveSource} implementation that reads from an artifact stored via
- * Jenkins {@link ArtifactManager} / {@link VirtualFile}.
+ * {@link AllureReportArchiveSource} that reads from a remote artifact store via
+ * {@link VirtualFile}. On first access, downloads the zip to the local artifacts
+ * directory ({@code <run.getArtifactsDir()>/allure-report.zip}) so that subsequent
+ * requests are served by {@link LocalFileArchiveSource} via the
+ * {@link FallbackArchiveSource} chain — identical behavior to a non-S3 setup.
  *
- * <p>This implementation does <em>not</em> require the archive to be present as a local
- * file on the master node Ã¢ it delegates all I/O to the {@link VirtualFile} API, which
- * may transparently read from S3, Azure Blob Storage, or any other pluggable back-end.
- *
- * <p>Because {@link VirtualFile} streams are opened on demand and closed by the caller,
- * this class itself holds no persistent resources and {@link #close()} is a no-op.
+ * <p>The local copy is naturally cleaned up by Jenkins' build discarder along with
+ * the rest of the build's artifacts.
  */
 public final class ArtifactManagerArchiveSource implements AllureReportArchiveSource {
 
-    private final Run<?, ?> run;
+    private static final Logger LOGGER = Logger.getLogger(ArtifactManagerArchiveSource.class.getName());
 
+    private final Run<?, ?> run;
     private VirtualFile artifactRoot;
+    private ZipFile localZipFile;
 
     public ArtifactManagerArchiveSource(final Run<?, ?> run) {
         this.run = run;
@@ -58,6 +70,12 @@ public final class ArtifactManagerArchiveSource implements AllureReportArchiveSo
 
     @Override
     public InputStream openEntry(final String entryPath) throws IOException, InterruptedException {
+        final String runId = run.getExternalizableId();
+
+        final InputStream cached = ReportEntryCache.getInstance().get(runId, entryPath);
+        if (cached != null) {
+            return cached;
+        }
 
         final VirtualFile root = getArtifactRoot();
         if (root == null) {
@@ -71,9 +89,23 @@ public final class ArtifactManagerArchiveSource implements AllureReportArchiveSo
 
         final VirtualFile zipBlob = root.child(AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP);
         if (!zipBlob.exists()) {
-            throw new NoSuchElementException("allure-report.zip not found in artifact store for run: "
-                    + run.getFullDisplayName());
+            throw new NoSuchElementException(
+                    "allure-report.zip not found in artifact store for run: " + run.getFullDisplayName());
         }
+
+        if (isLocalCacheApplicable(zipBlob)) {
+            final ZipFile zip = getOrDownloadToArtifactsDir(zipBlob);
+            final ZipEntry entry = zip.getEntry(entryPath);
+            if (entry == null) {
+                throw new NoSuchElementException("Entry not found in archive: " + entryPath);
+            }
+            try (InputStream is = zip.getInputStream(entry)) {
+                final byte[] data = is.readAllBytes();
+                ReportEntryCache.getInstance().put(runId, entryPath, data);
+                return new ByteArrayInputStream(data);
+            }
+        }
+
         return ZipEntryInputStream.open(zipBlob.open(), entryPath);
     }
 
@@ -95,12 +127,74 @@ public final class ArtifactManagerArchiveSource implements AllureReportArchiveSo
         if (!zipBlob.exists()) {
             return new ArrayList<>();
         }
+
+        if (isLocalCacheApplicable(zipBlob)) {
+            final ZipFile zip = getOrDownloadToArtifactsDir(zipBlob);
+            final List<String> result = new ArrayList<>();
+            final Enumeration<? extends ZipEntry> entries = zip.entries();
+            while (entries.hasMoreElements()) {
+                final ZipEntry entry = entries.nextElement();
+                if (entry.getName().startsWith(prefix) && !entry.isDirectory()) {
+                    result.add(entry.getName());
+                }
+            }
+            return result;
+        }
+
         return ZipEntryInputStream.listEntries(zipBlob.open(), prefix);
     }
 
     @Override
-    @SuppressWarnings("PMD.UncommentedEmptyMethodBody")
-    public void close() {
+    public void close() throws IOException {
+        if (localZipFile != null) {
+            localZipFile.close();
+            localZipFile = null;
+        }
+    }
+
+    private boolean isLocalCacheApplicable(final VirtualFile zipBlob) throws IOException {
+        final Jenkins jenkins = Jenkins.getInstanceOrNull();
+        if (jenkins == null) {
+            return false;
+        }
+        final AllureReportPublisherDescriptor descriptor =
+                jenkins.getDescriptorByType(AllureReportPublisherDescriptor.class);
+        if (descriptor == null || !descriptor.isLocalCacheEnabled()) {
+            return false;
+        }
+        final long thresholdBytes = descriptor.getLocalCacheThresholdMb() * 1024L * 1024L;
+        return zipBlob.length() >= thresholdBytes;
+    }
+
+    @SuppressWarnings("PMD.CloseResource")
+    private ZipFile getOrDownloadToArtifactsDir(final VirtualFile zipBlob)
+            throws IOException, InterruptedException {
+        if (localZipFile != null) {
+            return localZipFile;
+        }
+
+        final Path localPath = run.getArtifactsDir().toPath()
+                .resolve(AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP);
+
+        if (Files.exists(localPath)) {
+            LOGGER.log(Level.FINE, "Using existing local copy at {0}", localPath);
+            localZipFile = new ZipFile(localPath.toFile());
+            return localZipFile;
+        }
+
+        LOGGER.log(Level.INFO, "Downloading allure-report.zip from remote storage to {0} for run {1}",
+                new Object[]{localPath, run.getExternalizableId()});
+
+        Files.createDirectories(localPath.getParent());
+        final Path tmpFile = Files.createTempFile(localPath.getParent(), "allure-report-", ".zip.tmp");
+        try (InputStream is = zipBlob.open()) {
+            Files.copy(is, tmpFile, StandardCopyOption.REPLACE_EXISTING);
+        }
+        Files.move(tmpFile, localPath, StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.ATOMIC_MOVE);
+
+        localZipFile = new ZipFile(localPath.toFile());
+        return localZipFile;
     }
 
     private VirtualFile getArtifactRoot() {

--- a/src/main/java/org/allurereport/jenkins/utils/ReportEntryCache.java
+++ b/src/main/java/org/allurereport/jenkins/utils/ReportEntryCache.java
@@ -28,6 +28,8 @@ public final class ReportEntryCache {
     private static final long DEFAULT_MAX_BYTES = 200L * 1024 * 1024;
     private static final int INITIAL_CAPACITY = 64;
     private static final float LOAD_FACTOR = 0.75f;
+    private static final boolean ACCESS_ORDER = true;
+    private static final String KEY_SEPARATOR = "\0";
 
     private static final ReportEntryCache INSTANCE = new ReportEntryCache(DEFAULT_MAX_BYTES);
 
@@ -38,16 +40,13 @@ public final class ReportEntryCache {
     ReportEntryCache(final long maxBytes) {
         this.maxBytes = maxBytes;
         this.currentBytes = 0;
-        this.cache = new LinkedHashMap<String, byte[]>(INITIAL_CAPACITY, LOAD_FACTOR, true) {
-            @Override
-            protected boolean removeEldestEntry(final Map.Entry<String, byte[]> eldest) {
-                if (currentBytes > ReportEntryCache.this.maxBytes) {
-                    currentBytes -= eldest.getValue().length;
-                    return true;
-                }
-                return false;
-            }
-        };
+        // access-order map so iteration in trimToSize() evicts least-recently-used entries first.
+        // Eviction is driven solely by trimToSize() to keep currentBytes accounting in one place.
+        this.cache = new LinkedHashMap<>(INITIAL_CAPACITY, LOAD_FACTOR, ACCESS_ORDER);
+    }
+
+    private static String key(final String runId, final String entryPath) {
+        return runId + KEY_SEPARATOR + entryPath;
     }
 
     public static ReportEntryCache getInstance() {
@@ -55,8 +54,7 @@ public final class ReportEntryCache {
     }
 
     public synchronized InputStream get(final String runId, final String entryPath) {
-        final String key = runId + "\0" + entryPath;
-        final byte[] data = cache.get(key);
+        final byte[] data = cache.get(key(runId, entryPath));
         if (data == null) {
             return null;
         }
@@ -72,13 +70,12 @@ public final class ReportEntryCache {
         if (data.length > maxBytes) {
             return;
         }
-        final String key = runId + "\0" + entryPath;
-        final byte[] existing = cache.remove(key);
+        final byte[] existing = cache.remove(key(runId, entryPath));
         if (existing != null) {
             currentBytes -= existing.length;
         }
         currentBytes += data.length;
-        cache.put(key, data);
+        cache.put(key(runId, entryPath), data);
         trimToSize();
     }
 

--- a/src/main/java/org/allurereport/jenkins/utils/ReportEntryCache.java
+++ b/src/main/java/org/allurereport/jenkins/utils/ReportEntryCache.java
@@ -36,6 +36,7 @@ public final class ReportEntryCache {
     private final long maxBytes;
     private long currentBytes;
     private final Map<String, byte[]> cache;
+    private final Object lock = new Object();
 
     ReportEntryCache(final long maxBytes) {
         this.maxBytes = maxBytes;
@@ -53,30 +54,36 @@ public final class ReportEntryCache {
         return INSTANCE;
     }
 
-    public synchronized InputStream get(final String runId, final String entryPath) {
-        final byte[] data = cache.get(key(runId, entryPath));
-        if (data == null) {
-            return null;
+    public InputStream get(final String runId, final String entryPath) {
+        synchronized (lock) {
+            final byte[] data = cache.get(key(runId, entryPath));
+            if (data == null) {
+                return null;
+            }
+            return new ByteArrayInputStream(data);
         }
-        return new ByteArrayInputStream(data);
     }
 
-    public synchronized void clear() {
-        cache.clear();
-        currentBytes = 0;
+    public void clear() {
+        synchronized (lock) {
+            cache.clear();
+            currentBytes = 0;
+        }
     }
 
-    public synchronized void put(final String runId, final String entryPath, final byte[] data) {
-        if (data.length > maxBytes) {
-            return;
+    public void put(final String runId, final String entryPath, final byte[] data) {
+        synchronized (lock) {
+            if (data.length > maxBytes) {
+                return;
+            }
+            final byte[] existing = cache.remove(key(runId, entryPath));
+            if (existing != null) {
+                currentBytes -= existing.length;
+            }
+            currentBytes += data.length;
+            cache.put(key(runId, entryPath), data);
+            trimToSize();
         }
-        final byte[] existing = cache.remove(key(runId, entryPath));
-        if (existing != null) {
-            currentBytes -= existing.length;
-        }
-        currentBytes += data.length;
-        cache.put(key(runId, entryPath), data);
-        trimToSize();
     }
 
     private void trimToSize() {

--- a/src/main/java/org/allurereport/jenkins/utils/ReportEntryCache.java
+++ b/src/main/java/org/allurereport/jenkins/utils/ReportEntryCache.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.utils;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Bounded LRU cache for decompressed report entry bytes, keyed by (runId, entryPath).
+ */
+public final class ReportEntryCache {
+
+    private static final long DEFAULT_MAX_BYTES = 200L * 1024 * 1024;
+    private static final int INITIAL_CAPACITY = 64;
+    private static final float LOAD_FACTOR = 0.75f;
+
+    private static final ReportEntryCache INSTANCE = new ReportEntryCache(DEFAULT_MAX_BYTES);
+
+    private final long maxBytes;
+    private long currentBytes;
+    private final Map<String, byte[]> cache;
+
+    ReportEntryCache(final long maxBytes) {
+        this.maxBytes = maxBytes;
+        this.currentBytes = 0;
+        this.cache = new LinkedHashMap<String, byte[]>(INITIAL_CAPACITY, LOAD_FACTOR, true) {
+            @Override
+            protected boolean removeEldestEntry(final Map.Entry<String, byte[]> eldest) {
+                if (currentBytes > ReportEntryCache.this.maxBytes) {
+                    currentBytes -= eldest.getValue().length;
+                    return true;
+                }
+                return false;
+            }
+        };
+    }
+
+    public static ReportEntryCache getInstance() {
+        return INSTANCE;
+    }
+
+    public synchronized InputStream get(final String runId, final String entryPath) {
+        final String key = runId + "\0" + entryPath;
+        final byte[] data = cache.get(key);
+        if (data == null) {
+            return null;
+        }
+        return new ByteArrayInputStream(data);
+    }
+
+    public synchronized void clear() {
+        cache.clear();
+        currentBytes = 0;
+    }
+
+    public synchronized void put(final String runId, final String entryPath, final byte[] data) {
+        if (data.length > maxBytes) {
+            return;
+        }
+        final String key = runId + "\0" + entryPath;
+        final byte[] existing = cache.remove(key);
+        if (existing != null) {
+            currentBytes -= existing.length;
+        }
+        currentBytes += data.length;
+        cache.put(key, data);
+        trimToSize();
+    }
+
+    private void trimToSize() {
+        final java.util.Iterator<Map.Entry<String, byte[]>> iterator = cache.entrySet().iterator();
+        while (currentBytes > maxBytes && iterator.hasNext()) {
+            final Map.Entry<String, byte[]> entry = iterator.next();
+            currentBytes -= entry.getValue().length;
+            iterator.remove();
+        }
+    }
+}

--- a/src/main/resources/org/allurereport/jenkins/AllureReportPublisher/global.jelly
+++ b/src/main/resources/org/allurereport/jenkins/AllureReportPublisher/global.jelly
@@ -21,5 +21,13 @@
             </f:repeatable>
         </f:entry>
 
+        <f:optionalBlock name="localCacheEnabled" title="${%LocalCacheEnabled}"
+                         checked="${descriptor.isLocalCacheEnabled()}"
+                         inline="true">
+            <f:entry title="${%LocalCacheThresholdMb}" field="localCacheThresholdMb">
+                <f:number value="${descriptor.getLocalCacheThresholdMb()}" min="1"/>
+            </f:entry>
+        </f:optionalBlock>
+
     </f:section>
 </j:jelly>

--- a/src/main/resources/org/allurereport/jenkins/AllureReportPublisher/global.properties
+++ b/src/main/resources/org/allurereport/jenkins/AllureReportPublisher/global.properties
@@ -1,0 +1,3 @@
+Properties=Properties
+LocalCacheEnabled=Download report from remote ArtifactManager (S3/Azure) to local storage on first view
+LocalCacheThresholdMb=For files larger than (MB)

--- a/src/test/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSourceTest.java
+++ b/src/test/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSourceTest.java
@@ -20,6 +20,7 @@ import hudson.Launcher;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.StreamBuildListener;
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -51,6 +52,11 @@ public class ArtifactManagerArchiveSourceTest {
 
     @Rule
     public JenkinsRule jRule = new JenkinsRule();
+
+    @Before
+    public void setUp() {
+        ReportEntryCache.getInstance().clear();
+    }
 
     @Test
     public void openEntryReadsDirectArtifactWithoutZip() throws Exception {


### PR DESCRIPTION
When allure-report.zip is stored via a remote ArtifactManager (e.g. artifact-manager-s3), every HTTP request from the browser triggers a full download + sequential ZipInputStream scan of the entire archive. For a ~100 MB+ report, this caused 5s–2min delay per click.

This change introduces three complementary fixes:

1. On-demand local cache (opt-in): When enabled in global config, the first request downloads allure-report.zip to run.getArtifactsDir() so subsequent requests are served via LocalFileArchiveSource with ZipFile random-access (O(1) entry lookup). The local copy is naturally cleaned up by Jenkins' build discarder. A configurable size threshold (default 100 MB) controls which reports qualify.

2. In-memory LRU entry cache: A bounded (200 MB) cache of decompressed entry bytes keyed by (runId, entryPath). The Allure shell assets (~5 MB total: index.html, app.js, CSS, top-level widgets) are served from memory on subsequent navigations with zero I/O.

3. Immutable HTTP cache headers: Report content is immutable per build, so Cache-Control is changed from "no-cache, no-store" to "public, max-age=31536000, immutable". Browser back/forward navigation now costs zero requests to Jenkins.

The feature is opt-in via Manage Jenkins > System > Allure Report: "Download report from remote ArtifactManager to local storage on first view" with a configurable size threshold.

Fixes #454

### Testing done
Plugin built, tests passed, 
 All green:

  Tests run: 111, Failures: 0, Errors: 0, Skipped: 0
  BUILD SUCCESS

Also tested by installation on the Jenkins instance



