### PR TITLE
Speed up Allure report browsing with remote artifact storage

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -107,3 +107,64 @@ jobs:
           else
             echo "- Compatibility smoke did not produce an Allure 3 dump." >> "$GITHUB_STEP_SUMMARY"
           fi
+
+  s3-compat:
+    runs-on: ubuntu-latest
+    needs: build-plugin
+    timeout-minutes: 45
+    env:
+      JENKINS_VERSION: '2.528.3'
+      COMPAT_ID: '2.528.3-s3'
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+          package-manager-cache: false
+      - name: Download plugin hpi
+        uses: actions/download-artifact@v4
+        with:
+          name: plugin-hpi
+          path: target
+      - name: Run S3 Artifact Manager latency compatibility test
+        env:
+          COMPAT_ARTIFACT_ROOT: ${{ github.workspace }}/compat-artifacts/${{ env.COMPAT_ID }}
+          ALLURE_DUMP: ${{ github.workspace }}/allure-dumps/compat-${{ env.COMPAT_ID }}
+        run: |
+          mkdir -p "${ALLURE_DUMP%/*}"
+          npx --yes allure@3 run \
+            --dump="$ALLURE_DUMP" \
+            --environment="jenkins-${COMPAT_ID//[^a-zA-Z0-9_-]/-}" \
+            -- ./mvnw -B -e -ntp -f compat/jenkins-smoke/pom.xml \
+              -Ps3-compat \
+              -Dtest=S3ArtifactManagerCompatibilityTest \
+              -Dcompat.rootDir="${{ github.workspace }}" \
+              -Dcompat.version="$JENKINS_VERSION" \
+              -Dcompat.artifactRoot="$COMPAT_ARTIFACT_ROOT" \
+              test
+      - name: Upload S3 compatibility Allure 3 dump
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: compat-${{ env.COMPAT_ID }}-allure3-dump
+          path: allure-dumps/compat-${{ env.COMPAT_ID }}.zip
+          if-no-files-found: error
+      - name: Append S3 compatibility summary
+        if: always()
+        run: |
+          DUMP_PATH="allure-dumps/compat-${COMPAT_ID}.zip"
+          echo "## Jenkins ${JENKINS_VERSION} + S3 Artifact Manager" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -f "$DUMP_PATH" ]]; then
+            DUMP_SIZE=$(du -h "$DUMP_PATH" | cut -f1)
+            echo "- Allure 3 dump: \`${DUMP_PATH}\` (${DUMP_SIZE})" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Workflow artifact: \`compat-${COMPAT_ID}-allure3-dump\`" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Evidence: MinIO/Toxiproxy configuration, remote archive state, latency metrics, and container logs" >> "$GITHUB_STEP_SUMMARY"
+            echo "- Generate a report: \`npx --yes allure@3 generate --config ./allurerc.mjs --dump=${DUMP_PATH}\`" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- S3 compatibility test did not produce an Allure 3 dump." >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/compat/README.md
+++ b/compat/README.md
@@ -9,12 +9,21 @@ The suite starts a real Jenkins controller in Docker with Testcontainers, instal
 - Freestyle report generation with and without the optional `matrix-project` plugin installed
 - Pipeline step execution
 - Matrix build aggregation when `matrix-project` is installed
+- Remote report browsing through `artifact-manager-s3` backed by MinIO, with Toxiproxy enforcing a slow download link
 
 The harness stages Allure results, Surefire reports, Jenkins logs, console output, and report HTML under `compat-artifacts/` while it runs. GitHub Actions wraps the suite with Allure 3 and uploads a single `compat-<version>.zip` dump instead of that raw directory. The dump preserves the Allure results and their evidence attachments.
 
 Shared diagnostics are stored as global attachments: the Jenkins controller log, Jenkins initialization and setup scripts, the plugin list, and Maven stdout and stderr. Job-specific Groovy checks, JSON responses, console logs, and report pages remain attached to the test that produced them. Surefire reports stay in the local staging directory and are not duplicated in the dump.
 
 Pull requests run the suite against Jenkins `2.462.1` when plugin, build, workflow, or compatibility-harness files change. A newer commit on the same pull request cancels the superseded run. Use the manual workflow input to test an additional Jenkins version or exact Docker tag.
+
+The S3 latency scenario runs as a separate job against Jenkins `2.528.3` and
+`artifact-manager-s3:962.v15f7000205fa_`. It creates a 64 MiB incompressible
+report attachment in MinIO, verifies that the report ZIP is remote and that
+`index.html` follows more than 50 MiB of data, then constrains downstream S3
+traffic to 1024 KiB/s with 150 ms latency. The first uncached index response must
+return in under 10 seconds with the build-scoped immutable cache header. A full
+archive download under that bandwidth limit would take about a minute.
 
 ## Local Dry Run
 
@@ -52,3 +61,29 @@ npx --yes allure@3 generate \
   --config ./allurerc.mjs \
   --dump=allure-dumps/compat-2.462.1.zip
 ```
+
+## S3 Artifact Manager Latency Test
+
+The `s3-compat` Maven profile opts into the Docker-backed S3 scenario and defaults
+to Jenkins `2.528.3`. MinIO and Toxiproxy are pulled automatically; no local S3
+credentials or service are required. Run it through Allure agent mode so the
+remote archive facts, proxy settings, measured latency, and container logs stay
+reviewable:
+
+```bash
+npx --yes allure@3 agent \
+  --results-dir "$PWD/compat-artifacts/2.528.3-s3/allure-results" \
+  --goal "Confirm Jenkins 2.528.3 serves a greater-than-50-MiB Allure report from S3 within the constrained-link latency budget" \
+  --expect-test "org.allurereport.jenkins.compat.S3ArtifactManagerCompatibilityTest.shouldServeLargeS3ReportWithinLatencyBudget" \
+  -- ./mvnw -B -e -ntp -f compat/jenkins-smoke/pom.xml \
+    -Ps3-compat \
+    -Dtest=S3ArtifactManagerCompatibilityTest \
+    -Dcompat.rootDir="$PWD" \
+    -Dcompat.version=2.528.3 \
+    -Dcompat.artifactRoot="$PWD/compat-artifacts/2.528.3-s3" \
+    test
+```
+
+The regular compatibility command leaves this test visibly skipped because the
+profile is disabled. CI stores the opt-in run separately as
+`compat-2.528.3-s3-allure3-dump`.

--- a/compat/jenkins-smoke/pom.xml
+++ b/compat/jenkins-smoke/pom.xml
@@ -12,6 +12,7 @@
     <properties>
         <allure.junit5.version>2.29.1</allure.junit5.version>
         <compat.rootDir>${project.basedir}/../..</compat.rootDir>
+        <compat.s3.enabled>false</compat.s3.enabled>
         <compat.version>2.462.1</compat.version>
         <compat.artifactRoot>${compat.rootDir}/compat-artifacts/${compat.version}</compat.artifactRoot>
         <jackson.version>2.18.2</jackson.version>
@@ -85,6 +86,7 @@
                         <allure.results.directory>${compat.artifactRoot}/allure-results</allure.results.directory>
                         <compat.artifactRoot>${compat.artifactRoot}</compat.artifactRoot>
                         <compat.rootDir>${compat.rootDir}</compat.rootDir>
+                        <compat.s3.enabled>${compat.s3.enabled}</compat.s3.enabled>
                         <compat.version>${compat.version}</compat.version>
                     </systemPropertyVariables>
                 </configuration>
@@ -98,4 +100,14 @@
             <url>https://repo.maven.apache.org/maven2</url>
         </repository>
     </repositories>
+
+    <profiles>
+        <profile>
+            <id>s3-compat</id>
+            <properties>
+                <compat.s3.enabled>true</compat.s3.enabled>
+                <compat.version>2.528.3</compat.version>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/compat/jenkins-smoke/src/test/java/org/allurereport/jenkins/compat/S3ArtifactManagerCompatibilityTest.java
+++ b/compat/jenkins-smoke/src/test/java/org/allurereport/jenkins/compat/S3ArtifactManagerCompatibilityTest.java
@@ -1,0 +1,822 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.compat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.qameta.allure.Allure;
+import io.qameta.allure.Description;
+import io.qameta.allure.Epic;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Story;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Properties;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises report browsing through the real S3 Artifact Manager on a deterministic slow link.
+ */
+@Epic("Compatibility")
+@Feature("Remote artifact storage")
+@Tag("s3")
+@EnabledIfSystemProperty(named = "compat.s3.enabled", matches = "true")
+class S3ArtifactManagerCompatibilityTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private static final Pattern ALLURE_CLI_VERSION_PATTERN =
+            Pattern.compile("<allureCommandline\\.version>([^<]+)</allureCommandline\\.version>");
+    private static final Pattern URL_QUERY_PATTERN = Pattern.compile("(https?://[^\\s?]+)\\?[^\\s]+", Pattern.CASE_INSENSITIVE);
+
+    private static final String ISSUE_URL = "https://github.com/jenkinsci/allure-plugin/issues/454";
+    private static final String ARTIFACT_MANAGER_S3_VERSION = "962.v15f7000205fa_";
+    private static final String MINIO_IMAGE = "minio/minio:RELEASE.2025-09-07T16-13-09Z";
+    private static final String TOXIPROXY_IMAGE = "ghcr.io/shopify/toxiproxy:2.5.0";
+    private static final String PLUGIN_FILE_IN_IMAGE = "allure-jenkins-plugin.jpi";
+    private static final String FIXTURE_FILE_IN_IMAGE = "s3-latency-result.json";
+    private static final String JENKINS_INIT_FILE = "compat-init.groovy";
+    private static final String S3_BUCKET = "allure-compat";
+    private static final String S3_PREFIX = "compat/";
+    private static final String S3_CREDENTIALS_ID = "minio-compat";
+    private static final String MINIO_ALIAS = "minio";
+    private static final String S3_PROXY_ALIAS = "s3-proxy";
+    private static final String MINIO_USER = "minioadmin";
+    private static final String MINIO_PASSWORD = "minioadmin";
+    private static final String TARGET_ARCHIVE_ENTRY = "allure-report/index.html";
+
+    private static final int MINIO_PORT = 9000;
+    private static final int TOXIPROXY_CONTROL_PORT = 8474;
+    private static final int TOXIPROXY_S3_PORT = 8666;
+    private static final int GENERATED_ATTACHMENT_MEBIBYTES = 64;
+    private static final int DOWNSTREAM_BANDWIDTH_KILOBYTES_PER_SECOND = 1024;
+    private static final int DOWNSTREAM_LATENCY_MILLIS = 150;
+    private static final long MINIMUM_BYTES_BEFORE_TARGET = 50L * 1024L * 1024L;
+
+    private static final Duration STARTUP_TIMEOUT = Duration.ofMinutes(10);
+    private static final Duration READY_TIMEOUT = Duration.ofMinutes(5);
+    private static final Duration BUILD_TIMEOUT = Duration.ofMinutes(10);
+    private static final Duration HTTP_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration REPORT_FETCH_TIMEOUT = Duration.ofSeconds(20);
+    private static final Duration REPORT_LATENCY_BUDGET = Duration.ofSeconds(10);
+    private static final long POLL_DELAY_MILLIS = 2_000L;
+
+    private static final List<String> REQUIRED_PLUGINS = List.of(
+            "bouncycastle-api:2.30.1.79-254.vfdb_814e7791e",
+            "commons-lang3-api:3.17.0-84.vb_b_938040b_078",
+            "jackson2-api:2.17.0-389.va_5c7e45cd806",
+            "display-url-api:2.204.vf6fddd8a_8b_e9",
+            "artifact-manager-s3:" + ARTIFACT_MANAGER_S3_VERSION
+    );
+
+    private final HttpClient httpClient = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .followRedirects(HttpClient.Redirect.NORMAL)
+            .build();
+
+    @Test
+    @DisplayName("S3-backed report index stays responsive on a slow link")
+    @Story("Remote archive random access")
+    @Description("Stores a large Allure report through Jenkins' S3 Artifact Manager, constrains the MinIO "
+            + "download link, and verifies that the first uncached index request does not stream the full archive.")
+    void shouldServeLargeS3ReportWithinLatencyBudget() throws Exception {
+        final Configuration config = Configuration.fromSystemProperties();
+        final S3TestHarness harness = createTestHarness(config);
+        final Path artifactRoot = config.artifactRoot();
+
+        addTestParameters(config, harness);
+        Allure.link("Remote ArtifactManager latency regression", ISSUE_URL);
+
+        try (Network network = Network.newNetwork();
+             GenericContainer<?> minio = createMinioContainer(network);
+             GenericContainer<?> toxiproxy = createToxiproxyContainer(network);
+             GenericContainer<?> jenkins = harness.createJenkinsContainer(network)) {
+            try {
+                Allure.step("Start MinIO and the S3 network proxy", () -> {
+                    minio.start();
+                    toxiproxy.start();
+                    createS3Proxy(toxiproxy);
+                });
+
+                Allure.step("Start Jenkins with Allure and S3 Artifact Manager", jenkins::start);
+
+                final String baseUrl = "http://" + jenkins.getHost() + ":" + jenkins.getMappedPort(8080) + "/";
+                Allure.parameter("Jenkins base URL", baseUrl);
+                writeAllureEnvironment(config, harness, baseUrl);
+
+                Allure.step("Wait for the Jenkins script console", () -> waitForScriptConsole(baseUrl));
+
+                final String setupScript = buildSetupScript(harness.allureCliVersion());
+                final Path setupScriptPath = writeTextFile(
+                        harness.generatedDir().resolve("s3-setup.groovy"),
+                        setupScript
+                );
+                Allure.parameter("S3 setup script", setupScriptPath.toString());
+                final JsonNode setup = Allure.step("Configure MinIO as Jenkins' artifact manager", () -> {
+                    Allure.addAttachment("S3 Jenkins setup", "text/x-groovy", setupScript, ".groovy");
+                    final JsonNode response = executeScriptForJson(baseUrl, setupScript, HTTP_TIMEOUT);
+                    Allure.addAttachment(
+                            "S3 Jenkins setup response",
+                            "application/json",
+                            OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(response),
+                            ".json"
+                    );
+                    return response;
+                });
+                assertEquals(ARTIFACT_MANAGER_S3_VERSION, setup.path("artifactManagerS3Version").asText());
+                assertEquals(S3_BUCKET, setup.path("bucket").asText());
+                assertEquals(S3_PROXY_ALIAS + ":" + TOXIPROXY_S3_PORT, setup.path("endpoint").asText());
+
+                final JsonNode build = runS3Build(baseUrl, harness.generatedDir());
+                assertEquals("SUCCESS", build.path("result").asText());
+                assertTrue(build.path("archiveExists").asBoolean(), "The report archive must exist in MinIO");
+                assertFalse(build.path("localArchiveExists").asBoolean(),
+                        "The report archive must not be stored under the Jenkins build directory");
+                assertTrue(build.path("archiveBytes").asLong() >= MINIMUM_BYTES_BEFORE_TARGET,
+                        "The remote report archive must be at least 50 MiB");
+                assertTrue(build.path("uncompressedBytesBeforeIndex").asLong() >= MINIMUM_BYTES_BEFORE_TARGET,
+                        "The target index entry must follow at least 50 MiB of report data");
+
+                final String proxyState = Allure.step("Constrain the S3 download link", () -> {
+                    addSlowLinkToxics(toxiproxy);
+                    final String state = getToxiproxyState(toxiproxy);
+                    Allure.addAttachment("Toxiproxy S3 link state", "application/json", state, ".json");
+                    return state;
+                });
+
+                final String reportUrl = joinUrl(
+                        baseUrl,
+                        build.path("buildUrl").asText()
+                                + build.path("actionUrlName").asText()
+                                + "/index.html"
+                );
+                Allure.link("S3-backed Allure report", reportUrl);
+
+                final Instant startedAt = Instant.now();
+                final HttpTextResponse report = Allure.step(
+                        "Fetch the first uncached report index over the constrained S3 link",
+                        () -> getText(reportUrl, REPORT_FETCH_TIMEOUT)
+                );
+                final Duration elapsed = Duration.between(startedAt, Instant.now());
+
+                final Map<String, Object> metrics = new LinkedHashMap<>();
+                metrics.put("archiveBytes", build.path("archiveBytes").asLong());
+                metrics.put("uncompressedBytesBeforeIndex", build.path("uncompressedBytesBeforeIndex").asLong());
+                metrics.put("targetArchiveEntry", TARGET_ARCHIVE_ENTRY);
+                metrics.put("downstreamBandwidthKilobytesPerSecond", DOWNSTREAM_BANDWIDTH_KILOBYTES_PER_SECOND);
+                metrics.put("downstreamLatencyMillis", DOWNSTREAM_LATENCY_MILLIS);
+                metrics.put("latencyBudgetMillis", REPORT_LATENCY_BUDGET.toMillis());
+                metrics.put("observedLatencyMillis", elapsed.toMillis());
+                metrics.put("statusCode", report.statusCode());
+                metrics.put("cacheControl", report.cacheControl());
+                metrics.put("toxiproxy", OBJECT_MAPPER.readTree(proxyState));
+                Allure.addAttachment(
+                        "S3 report latency metrics",
+                        "application/json",
+                        OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(metrics),
+                        ".json"
+                );
+
+                Allure.parameter("Remote archive bytes", build.path("archiveBytes").asLong());
+                Allure.parameter("Bytes before index entry", build.path("uncompressedBytesBeforeIndex").asLong());
+                Allure.parameter("Observed report latency (ms)", elapsed.toMillis());
+                Allure.parameter("Report latency budget (ms)", REPORT_LATENCY_BUDGET.toMillis());
+
+                assertEquals(200, report.statusCode());
+                assertTrue(report.body().toLowerCase(Locale.ROOT).contains("<html"),
+                        "The response must contain the Allure report index");
+                assertEquals("private, max-age=31536000, immutable", report.cacheControl());
+                assertTrue(elapsed.compareTo(REPORT_LATENCY_BUDGET) < 0,
+                        () -> "Expected the S3-backed index in less than " + REPORT_LATENCY_BUDGET.toSeconds()
+                                + " seconds, but it took " + elapsed.toMillis() + " ms");
+            } finally {
+                captureContainerEvidence(artifactRoot, "jenkins-s3", jenkins, true);
+                captureContainerEvidence(artifactRoot, "minio", minio, false);
+                captureContainerEvidence(artifactRoot, "toxiproxy", toxiproxy, false);
+            }
+        }
+    }
+
+    private JsonNode runS3Build(final String baseUrl, final Path generatedDir) throws Exception {
+        final String script = buildS3CheckScript();
+        final Path scriptPath = writeTextFile(generatedDir.resolve("s3-build-check.groovy"), script);
+        Allure.parameter("S3 build check script", scriptPath.toString());
+
+        return Allure.step("Publish the large report to MinIO and inspect its remote archive", () -> {
+            Allure.addAttachment("S3 build check", "text/x-groovy", script, ".groovy");
+            final JsonNode response = executeScriptForJson(baseUrl, script, BUILD_TIMEOUT);
+            Allure.addAttachment(
+                    "S3 build and archive response",
+                    "application/json",
+                    OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(response),
+                    ".json"
+            );
+            return response;
+        });
+    }
+
+    private void addTestParameters(final Configuration config, final S3TestHarness harness) {
+        Allure.parameter("Jenkins requested version", config.requestedVersion());
+        Allure.parameter("Jenkins Docker tag", config.normalizedImageTag());
+        Allure.parameter("Plugin artifact", harness.pluginArtifact().toString());
+        Allure.parameter("Allure CLI version", harness.allureCliVersion());
+        Allure.parameter("S3 Artifact Manager version", ARTIFACT_MANAGER_S3_VERSION);
+        Allure.parameter("MinIO image", MINIO_IMAGE);
+        Allure.parameter("Toxiproxy image", TOXIPROXY_IMAGE);
+        Allure.parameter("Generated attachment (MiB)", GENERATED_ATTACHMENT_MEBIBYTES);
+        Allure.parameter("Downstream bandwidth (KiB/s)", DOWNSTREAM_BANDWIDTH_KILOBYTES_PER_SECOND);
+        Allure.parameter("Downstream latency (ms)", DOWNSTREAM_LATENCY_MILLIS);
+    }
+
+    private GenericContainer<?> createMinioContainer(final Network network) {
+        return new GenericContainer<>(DockerImageName.parse(MINIO_IMAGE))
+                .withNetwork(network)
+                .withNetworkAliases(MINIO_ALIAS)
+                .withExposedPorts(MINIO_PORT)
+                .withEnv("MINIO_ROOT_USER", MINIO_USER)
+                .withEnv("MINIO_ROOT_PASSWORD", MINIO_PASSWORD)
+                .withCommand("server", "--console-address", ":9001", "/data")
+                .waitingFor(Wait.forHttp("/minio/health/ready").forPort(MINIO_PORT))
+                .withStartupTimeout(STARTUP_TIMEOUT);
+    }
+
+    private GenericContainer<?> createToxiproxyContainer(final Network network) {
+        return new GenericContainer<>(DockerImageName.parse(TOXIPROXY_IMAGE))
+                .withNetwork(network)
+                .withNetworkAliases(S3_PROXY_ALIAS)
+                .withExposedPorts(TOXIPROXY_CONTROL_PORT)
+                .waitingFor(Wait.forHttp("/version").forPort(TOXIPROXY_CONTROL_PORT))
+                .withStartupTimeout(STARTUP_TIMEOUT);
+    }
+
+    private void createS3Proxy(final GenericContainer<?> toxiproxy) throws Exception {
+        postToxiproxyJson(toxiproxy, "/proxies", Map.of(
+                "name", "minio",
+                "listen", "0.0.0.0:" + TOXIPROXY_S3_PORT,
+                "upstream", MINIO_ALIAS + ":" + MINIO_PORT
+        ));
+    }
+
+    private void addSlowLinkToxics(final GenericContainer<?> toxiproxy) throws Exception {
+        postToxiproxyJson(toxiproxy, "/proxies/minio/toxics", Map.of(
+                "name", "s3-downstream-bandwidth",
+                "type", "bandwidth",
+                "stream", "downstream",
+                "toxicity", 1.0,
+                "attributes", Map.of("rate", DOWNSTREAM_BANDWIDTH_KILOBYTES_PER_SECOND)
+        ));
+        postToxiproxyJson(toxiproxy, "/proxies/minio/toxics", Map.of(
+                "name", "s3-downstream-latency",
+                "type", "latency",
+                "stream", "downstream",
+                "toxicity", 1.0,
+                "attributes", Map.of("latency", DOWNSTREAM_LATENCY_MILLIS, "jitter", 0)
+        ));
+    }
+
+    private void postToxiproxyJson(final GenericContainer<?> toxiproxy,
+                                   final String path,
+                                   final Map<String, ?> payload) throws Exception {
+        final HttpRequest request = HttpRequest.newBuilder(toxiproxyUri(toxiproxy, path))
+                .timeout(HTTP_TIMEOUT)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(OBJECT_MAPPER.writeValueAsString(payload)))
+                .build();
+        final HttpResponse<String> response = httpClient.send(
+                request,
+                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8)
+        );
+        if (response.statusCode() < 200 || response.statusCode() >= 300) {
+            throw new IllegalStateException("Toxiproxy returned HTTP " + response.statusCode() + ": "
+                    + response.body());
+        }
+    }
+
+    private String getToxiproxyState(final GenericContainer<?> toxiproxy) throws Exception {
+        final HttpRequest request = HttpRequest.newBuilder(toxiproxyUri(toxiproxy, "/proxies/minio"))
+                .timeout(HTTP_TIMEOUT)
+                .GET()
+                .build();
+        final HttpResponse<String> response = httpClient.send(
+                request,
+                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8)
+        );
+        if (response.statusCode() != 200) {
+            throw new IllegalStateException("Toxiproxy returned HTTP " + response.statusCode() + ": "
+                    + response.body());
+        }
+        return response.body();
+    }
+
+    private URI toxiproxyUri(final GenericContainer<?> toxiproxy, final String path) {
+        return URI.create("http://" + toxiproxy.getHost() + ":"
+                + toxiproxy.getMappedPort(TOXIPROXY_CONTROL_PORT) + path);
+    }
+
+    private void waitForScriptConsole(final String baseUrl) throws Exception {
+        final Instant deadline = Instant.now().plus(READY_TIMEOUT);
+        Exception lastFailure = null;
+        while (Instant.now().isBefore(deadline)) {
+            try {
+                final String response = executeScript(baseUrl, "println('ready')", HTTP_TIMEOUT);
+                if ("ready".equals(response.trim())) {
+                    return;
+                }
+            } catch (Exception exception) {
+                lastFailure = exception;
+            }
+            Thread.sleep(POLL_DELAY_MILLIS);
+        }
+        throw new IllegalStateException("Timed out waiting for the Jenkins script console", lastFailure);
+    }
+
+    private JsonNode executeScriptForJson(final String baseUrl,
+                                          final String script,
+                                          final Duration timeout) throws Exception {
+        final String response = executeScript(baseUrl, script, timeout).trim();
+        try {
+            return OBJECT_MAPPER.readTree(response);
+        } catch (IOException exception) {
+            throw new IllegalStateException("Expected JSON response from Jenkins but got:\n" + response, exception);
+        }
+    }
+
+    private String executeScript(final String baseUrl,
+                                 final String script,
+                                 final Duration timeout) throws Exception {
+        final String payload = "script=" + URLEncoder.encode(script, StandardCharsets.UTF_8);
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(joinUrl(baseUrl, "scriptText")))
+                .timeout(timeout)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(payload, StandardCharsets.UTF_8))
+                .build();
+        final HttpResponse<String> response = httpClient.send(
+                request,
+                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8)
+        );
+        if (response.statusCode() != 200) {
+            throw new IllegalStateException("Jenkins script console returned HTTP " + response.statusCode()
+                    + ":\n" + response.body());
+        }
+        return response.body();
+    }
+
+    private HttpTextResponse getText(final String url, final Duration timeout) throws Exception {
+        final HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                .timeout(timeout)
+                .GET()
+                .build();
+        final HttpResponse<String> response = httpClient.send(
+                request,
+                HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8)
+        );
+        return new HttpTextResponse(
+                response.statusCode(),
+                response.body(),
+                response.headers().firstValue("Cache-Control").orElse("")
+        );
+    }
+
+    private static S3TestHarness createTestHarness(final Configuration config) throws IOException {
+        Files.createDirectories(config.artifactRoot());
+        final Path generatedDir = Files.createDirectories(config.artifactRoot().resolve("generated-s3"));
+        final Path pluginArtifact = locatePluginArtifact(config.rootDir());
+        final Path fixture = config.rootDir().resolve(
+                "compat/jenkins-smoke/src/test/resources/s3-latency-result.json"
+        );
+        assertFileExists(fixture, "S3 latency result fixture");
+        final String allureCliVersion = resolveAllureCliVersion(config.rootDir());
+        final Path pluginsTxt = writeTextFile(
+                generatedDir.resolve("plugins.txt"),
+                REQUIRED_PLUGINS.stream().collect(Collectors.joining(System.lineSeparator()))
+                        + System.lineSeparator()
+        );
+        final Path initGroovy = writeTextFile(generatedDir.resolve(JENKINS_INIT_FILE), buildInitScript());
+        final ImageFromDockerfile image = createJenkinsImage(
+                config,
+                pluginArtifact,
+                fixture,
+                pluginsTxt,
+                initGroovy
+        );
+        return new S3TestHarness(config, generatedDir, pluginArtifact, allureCliVersion, image);
+    }
+
+    private static ImageFromDockerfile createJenkinsImage(final Configuration config,
+                                                           final Path pluginArtifact,
+                                                           final Path fixture,
+                                                           final Path pluginsTxt,
+                                                           final Path initGroovy) throws IOException {
+        final String imageName = "allure-jenkins-s3-compat-"
+                + Integer.toHexString(config.normalizedImageTag().hashCode()).toLowerCase(Locale.ROOT)
+                + "-" + Long.toHexString(Files.getLastModifiedTime(pluginArtifact).toMillis());
+
+        return new ImageFromDockerfile(imageName, false)
+                .withFileFromPath("plugins.txt", pluginsTxt)
+                .withFileFromPath(JENKINS_INIT_FILE, initGroovy)
+                .withFileFromPath(FIXTURE_FILE_IN_IMAGE, fixture)
+                .withFileFromPath(PLUGIN_FILE_IN_IMAGE, pluginArtifact)
+                .withDockerfileFromBuilder(builder -> builder
+                        .from("jenkins/jenkins:" + config.normalizedImageTag())
+                        .user("root")
+                        .run("mkdir -p /usr/share/jenkins/ref/plugins "
+                                + "/usr/share/jenkins/ref/smoke-data /usr/share/jenkins/ref/init.groovy.d")
+                        .copy("plugins.txt", "/usr/share/jenkins/ref/plugins.txt")
+                        .run("chown -R jenkins:jenkins /usr/share/jenkins/ref")
+                        .user("jenkins")
+                        .run("jenkins-plugin-cli --latest=false --plugin-file /usr/share/jenkins/ref/plugins.txt")
+                        .run("echo 2.0 > /usr/share/jenkins/ref/jenkins.install.UpgradeWizard.state")
+                        .user("root")
+                        .copy(JENKINS_INIT_FILE, "/usr/share/jenkins/ref/init.groovy.d/" + JENKINS_INIT_FILE)
+                        .copy(FIXTURE_FILE_IN_IMAGE, "/usr/share/jenkins/ref/smoke-data/" + FIXTURE_FILE_IN_IMAGE)
+                        .copy(PLUGIN_FILE_IN_IMAGE, "/usr/share/jenkins/ref/plugins/" + PLUGIN_FILE_IN_IMAGE)
+                        .run("chown -R jenkins:jenkins /usr/share/jenkins/ref")
+                        .user("jenkins")
+                        .build());
+    }
+
+    private static Path locatePluginArtifact(final Path rootDir) throws IOException {
+        final Path targetDir = rootDir.resolve("target");
+        if (Files.notExists(targetDir)) {
+            throw new IllegalStateException("Plugin target directory does not exist: " + targetDir);
+        }
+        try (Stream<Path> stream = Files.list(targetDir)) {
+            return stream
+                    .filter(path -> path.getFileName().toString().endsWith(".hpi"))
+                    .sorted()
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("No plugin .hpi artifact found in " + targetDir));
+        }
+    }
+
+    private static String resolveAllureCliVersion(final Path rootDir) throws IOException {
+        final String override = System.getProperty("compat.allureCliVersion");
+        if (override != null && !override.isBlank()) {
+            return override.trim();
+        }
+        final String pom = Files.readString(rootDir.resolve("pom.xml"), StandardCharsets.UTF_8);
+        final Matcher matcher = ALLURE_CLI_VERSION_PATTERN.matcher(pom);
+        if (matcher.find()) {
+            return matcher.group(1).trim();
+        }
+        throw new IllegalStateException("Unable to resolve allureCommandline.version from root pom.xml");
+    }
+
+    private static String buildInitScript() {
+        return """
+                import hudson.security.AuthorizationStrategy
+                import hudson.security.SecurityRealm
+                import jenkins.model.Jenkins
+
+                def jenkins = Jenkins.get()
+                jenkins.setNumExecutors(2)
+                jenkins.setSecurityRealm(SecurityRealm.NO_AUTHENTICATION)
+                jenkins.setAuthorizationStrategy(new AuthorizationStrategy.Unsecured())
+                jenkins.setCrumbIssuer(null)
+                jenkins.save()
+                """;
+    }
+
+    private static String buildSetupScript(final String allureCliVersion) {
+        return """
+                import com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl
+                import com.cloudbees.plugins.credentials.CredentialsProvider
+                import com.cloudbees.plugins.credentials.CredentialsScope
+                import com.cloudbees.plugins.credentials.domains.Domain
+                import groovy.json.JsonOutput
+                import hudson.model.FreeStyleProject
+                import hudson.tasks.Shell
+                import hudson.tools.InstallSourceProperty
+                import io.jenkins.plugins.artifact_manager_jclouds.JCloudsArtifactManagerFactory
+                import io.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStore
+                import io.jenkins.plugins.artifact_manager_jclouds.s3.S3BlobStoreConfig
+                import io.jenkins.plugins.aws.global_configuration.CredentialsAwsGlobalConfiguration
+                import jenkins.model.ArtifactManagerConfiguration
+                import jenkins.model.Jenkins
+                import org.allurereport.jenkins.AllureReportPublisher
+                import org.allurereport.jenkins.config.ResultsConfig
+                import org.allurereport.jenkins.tools.AllureCommandlineDirectInstaller
+                import org.allurereport.jenkins.tools.AllureCommandlineInstallation
+
+                def jenkins = Jenkins.get()
+                def credentialsId = %s
+                def minioUser = System.getenv('MINIO_ROOT_USER')
+                def minioPassword = System.getenv('MINIO_ROOT_PASSWORD')
+                def credentialsStore = CredentialsProvider.lookupStores(jenkins).iterator().next()
+                credentialsStore.addCredentials(
+                    Domain.global(),
+                    new AWSCredentialsImpl(
+                        CredentialsScope.GLOBAL,
+                        credentialsId,
+                        minioUser,
+                        minioPassword,
+                        'MinIO compatibility credentials'
+                    )
+                )
+
+                def awsConfig = CredentialsAwsGlobalConfiguration.get()
+                awsConfig.setRegion('us-east-1')
+                awsConfig.setCredentialsId(credentialsId)
+
+                def s3Config = S3BlobStoreConfig.get()
+                s3Config.setUseHttp(true)
+                s3Config.setUsePathStyleUrl(true)
+                s3Config.setDisableSessionToken(true)
+                s3Config.setCustomEndpoint(%s)
+                s3Config.setCustomSigningRegion('us-east-1')
+                s3Config.setContainer(%s)
+                s3Config.setPrefix(%s)
+                s3Config.createS3Bucket(%s)
+
+                ArtifactManagerConfiguration.get().artifactManagerFactories.replaceBy([
+                    new JCloudsArtifactManagerFactory(new S3BlobStore())
+                ])
+
+                def allureVersion = %s
+                def toolDescriptor = jenkins.getDescriptorByType(AllureCommandlineInstallation.DescriptorImpl.class)
+                if (toolDescriptor.installations.length == 0) {
+                    def installer = new AllureCommandlineDirectInstaller(allureVersion)
+                    def installation = new AllureCommandlineInstallation(
+                        'Allure ' + allureVersion,
+                        '',
+                        [new InstallSourceProperty([installer])]
+                    )
+                    toolDescriptor.setInstallations(installation)
+                    toolDescriptor.save()
+                }
+
+                def job = jenkins.getItem('compat-s3-latency')
+                if (!(job instanceof FreeStyleProject)) {
+                    if (job != null) {
+                        job.delete()
+                    }
+                    job = jenkins.createProject(FreeStyleProject, 'compat-s3-latency')
+                }
+                job.buildersList.clear()
+                job.publishersList.clear()
+                job.buildersList.add(new Shell(\"\"\"#!/bin/bash -e
+                rm -rf allure-results
+                mkdir -p allure-results
+                cp /usr/share/jenkins/ref/smoke-data/%s allure-results/s3-latency-result.json
+                dd if=/dev/urandom of=allure-results/large-attachment.bin bs=1M count=%d status=none
+                \"\"\".stripIndent()))
+                job.publishersList.add(new AllureReportPublisher(ResultsConfig.convertPaths(['allure-results'])))
+                job.save()
+                jenkins.save()
+
+                def artifactManagerPlugin = jenkins.pluginManager.getPlugin('artifact-manager-s3')
+                println(JsonOutput.toJson([
+                    artifactManagerS3Version: artifactManagerPlugin?.version,
+                    bucket: s3Config.container,
+                    prefix: s3Config.prefix,
+                    endpoint: s3Config.customEndpoint,
+                    useHttp: s3Config.useHttp,
+                    usePathStyleUrl: s3Config.usePathStyleUrl,
+                    disableSessionToken: s3Config.disableSessionToken,
+                    job: job.fullName
+                ]))
+                """.formatted(
+                groovyStringLiteral(S3_CREDENTIALS_ID),
+                groovyStringLiteral(S3_PROXY_ALIAS + ":" + TOXIPROXY_S3_PORT),
+                groovyStringLiteral(S3_BUCKET),
+                groovyStringLiteral(S3_PREFIX),
+                groovyStringLiteral(S3_BUCKET),
+                groovyStringLiteral(allureCliVersion),
+                FIXTURE_FILE_IN_IMAGE,
+                GENERATED_ATTACHMENT_MEBIBYTES
+        );
+    }
+
+    private static String buildS3CheckScript() {
+        return """
+                import groovy.json.JsonOutput
+                import java.util.zip.ZipInputStream
+                import jenkins.model.Jenkins
+                import org.allurereport.jenkins.AllureReportBuildAction
+
+                def job = Jenkins.get().getItemByFullName('compat-s3-latency')
+                if (job == null) {
+                    throw new IllegalStateException('compat-s3-latency job not found')
+                }
+                def future = job.scheduleBuild2(0)
+                if (future == null) {
+                    throw new IllegalStateException('Failed to schedule compat-s3-latency')
+                }
+                def build = future.get()
+                def action = build.getAction(AllureReportBuildAction)
+                if (action == null) {
+                    throw new IllegalStateException('Allure action is missing')
+                }
+
+                def manager = build.getArtifactManager()
+                def archive = manager.root().child('allure-report.zip')
+                def localArchive = new File(build.artifactsDir, 'allure-report.zip')
+                if (!archive.exists()) {
+                    throw new IllegalStateException('allure-report.zip is missing from the artifact manager')
+                }
+
+                long bytesBeforeIndex = 0
+                boolean foundIndex = false
+                def zip = new ZipInputStream(archive.open())
+                try {
+                    byte[] buffer = new byte[8192]
+                    def entry
+                    while ((entry = zip.nextEntry) != null) {
+                        if (entry.name == %s) {
+                            foundIndex = true
+                            break
+                        }
+                        int read
+                        while ((read = zip.read(buffer)) >= 0) {
+                            bytesBeforeIndex += read
+                        }
+                    }
+                } finally {
+                    zip.close()
+                }
+                if (!foundIndex) {
+                    throw new IllegalStateException('Target index entry is missing from allure-report.zip')
+                }
+
+                println(JsonOutput.toJson([
+                    result: String.valueOf(build.result),
+                    buildUrl: build.url,
+                    actionUrlName: action.urlName,
+                    artifactManagerClass: manager.class.name,
+                    archiveExists: archive.exists(),
+                    archiveBytes: archive.length(),
+                    localArchiveExists: localArchive.exists(),
+                    targetArchiveEntry: %s,
+                    uncompressedBytesBeforeIndex: bytesBeforeIndex,
+                    summary: [
+                        passed: action.buildSummary.passedCount,
+                        failed: action.buildSummary.failedCount,
+                        broken: action.buildSummary.brokenCount,
+                        skipped: action.buildSummary.skipCount,
+                        unknown: action.buildSummary.unknownCount
+                    ]
+                ]))
+                """.formatted(
+                groovyStringLiteral(TARGET_ARCHIVE_ENTRY),
+                groovyStringLiteral(TARGET_ARCHIVE_ENTRY)
+        );
+    }
+
+    private static void writeAllureEnvironment(final Configuration config,
+                                               final S3TestHarness harness,
+                                               final String baseUrl) throws IOException {
+        final Properties environment = new Properties();
+        environment.setProperty("Jenkins requested version", config.requestedVersion());
+        environment.setProperty("Jenkins Docker tag", config.normalizedImageTag());
+        environment.setProperty("Jenkins base URL", baseUrl);
+        environment.setProperty("Allure CLI version", harness.allureCliVersion());
+        environment.setProperty("S3 Artifact Manager version", ARTIFACT_MANAGER_S3_VERSION);
+        environment.setProperty("MinIO image", MINIO_IMAGE);
+        environment.setProperty("Toxiproxy image", TOXIPROXY_IMAGE);
+
+        final Path resultsDir = Files.createDirectories(config.artifactRoot().resolve("allure-results"));
+        try (var writer = Files.newBufferedWriter(resultsDir.resolve("environment.properties"), StandardCharsets.UTF_8)) {
+            environment.store(writer, "S3 compatibility test");
+        }
+    }
+
+    private static void captureContainerEvidence(final Path artifactRoot,
+                                                 final String name,
+                                                 final GenericContainer<?> container,
+                                                 final boolean redactUrls) {
+        try {
+            String logs = container.getLogs();
+            logs = logs.replace(MINIO_USER, "<redacted access key>")
+                    .replace(MINIO_PASSWORD, "<redacted secret key>");
+            if (redactUrls) {
+                logs = URL_QUERY_PATTERN.matcher(logs).replaceAll("$1?<redacted query>");
+            }
+            Allure.addAttachment(name + " container log", "text/plain", logs, ".log");
+            writeTextFile(artifactRoot.resolve(name + ".log"), logs);
+        } catch (RuntimeException | IOException ignored) {
+            // A container that failed before creation has no logs to preserve.
+        }
+    }
+
+    private static Path writeTextFile(final Path path, final String content) throws IOException {
+        Files.createDirectories(path.getParent());
+        Files.writeString(path, content, StandardCharsets.UTF_8);
+        return path;
+    }
+
+    private static void assertFileExists(final Path path, final String description) {
+        if (Files.notExists(path)) {
+            throw new IllegalStateException("Missing " + description + " file: " + path);
+        }
+    }
+
+    private static String joinUrl(final String baseUrl, final String relative) {
+        return baseUrl.endsWith("/") ? baseUrl + relative : baseUrl + "/" + relative;
+    }
+
+    private static String groovyStringLiteral(final String value) {
+        return "'" + value.replace("\\", "\\\\").replace("'", "\\'") + "'";
+    }
+
+    private static String sanitizeFileName(final String value) {
+        return value.replaceAll("[^A-Za-z0-9._-]", "_");
+    }
+
+    private record Configuration(Path rootDir,
+                                 String requestedVersion,
+                                 String normalizedImageTag,
+                                 Path artifactRoot) {
+
+        private static Configuration fromSystemProperties() {
+            final Path rootDir = Path.of(System.getProperty("compat.rootDir", "."))
+                    .toAbsolutePath()
+                    .normalize();
+            final String requestedVersion = System.getProperty("compat.version", "2.528.3").trim();
+            final String normalizedImageTag = normalizeJenkinsImageTag(requestedVersion);
+            final Path artifactRoot = Path.of(System.getProperty(
+                    "compat.artifactRoot",
+                    rootDir.resolve("compat-artifacts")
+                            .resolve(sanitizeFileName(requestedVersion) + "-s3")
+                            .toString()
+            )).toAbsolutePath().normalize();
+            return new Configuration(rootDir, requestedVersion, normalizedImageTag, artifactRoot);
+        }
+
+        private static String normalizeJenkinsImageTag(final String requestedVersion) {
+            if (requestedVersion.contains(":")) {
+                throw new IllegalArgumentException("compat.version must be a Jenkins Docker tag or bare version, "
+                        + "not a full image reference: " + requestedVersion);
+            }
+            if (requestedVersion.contains("jdk") || requestedVersion.contains("lts")
+                    || requestedVersion.contains("alpine")) {
+                return requestedVersion;
+            }
+            return requestedVersion + "-lts-jdk17";
+        }
+    }
+
+    private record S3TestHarness(Configuration config,
+                                 Path generatedDir,
+                                 Path pluginArtifact,
+                                 String allureCliVersion,
+                                 ImageFromDockerfile image) {
+
+        private GenericContainer<?> createJenkinsContainer(final Network network) {
+            return new GenericContainer<>(image)
+                    .withNetwork(network)
+                    .withNetworkAliases("jenkins")
+                    .withExposedPorts(8080)
+                    .withEnv("JAVA_OPTS", "-Djenkins.install.runSetupWizard=false")
+                    .withEnv("MINIO_ROOT_USER", MINIO_USER)
+                    .withEnv("MINIO_ROOT_PASSWORD", MINIO_PASSWORD)
+                    .waitingFor(Wait.forLogMessage(".*Jenkins is fully up and running.*\\n", 1))
+                    .withStartupTimeout(STARTUP_TIMEOUT);
+        }
+    }
+
+    private record HttpTextResponse(int statusCode, String body, String cacheControl) {
+    }
+}

--- a/compat/jenkins-smoke/src/test/resources/s3-latency-result.json
+++ b/compat/jenkins-smoke/src/test/resources/s3-latency-result.json
@@ -1,0 +1,24 @@
+{
+  "uuid": "s3-latency-result",
+  "historyId": "s3-latency-result",
+  "testCaseId": "s3-latency-result",
+  "fullName": "compatibility.s3.remote archive latency",
+  "labels": [
+    {
+      "name": "suite",
+      "value": "S3 compatibility"
+    }
+  ],
+  "name": "remote archive latency fixture",
+  "status": "passed",
+  "stage": "finished",
+  "start": 1704067200000,
+  "stop": 1704067201000,
+  "attachments": [
+    {
+      "name": "large incompressible payload",
+      "source": "large-attachment.bin",
+      "type": "application/octet-stream"
+    }
+  ]
+}

--- a/docs/allure-agent-mode.md
+++ b/docs/allure-agent-mode.md
@@ -32,12 +32,13 @@ The `allure@3` selector intentionally floats to the newest Allure 3 release publ
 | Regular unit tests | Maven Surefire + JUnit 4 | `src/test/java/**/*Test.java` | `target/allure-results` | Java and Maven wrapper |
 | Regular integration tests | Maven Failsafe + JUnit 4 | `src/test/java/**/*IT.java` | `target/allure-results` | Jenkins test harness; the build downloads an Allure commandline fixture |
 | Jenkins compatibility smoke | Maven Surefire + JUnit 5/Testcontainers | `compat/jenkins-smoke/src/test/java` | `compat-artifacts/<jenkins-version>/allure-results` | Docker, Java 17, and a built plugin HPI |
+| S3 Artifact Manager compatibility | Maven Surefire + JUnit 5/Testcontainers | `S3ArtifactManagerCompatibilityTest` | `compat-artifacts/2.528.3-s3/allure-results` | Docker, Java 17, a built plugin HPI, and the `s3-compat` profile; MinIO and Toxiproxy images are pulled automatically |
 
 The regular test adapter is configured in `pom.xml`; its stable result path is configured in `src/test/resources/allure.properties`. The compatibility runner has its own adapter and result path in `compat/jenkins-smoke/pom.xml`.
 
 The Jenkins plugin harness also executes generated validation tests under `org.jvnet.hudson.test`. They are part of the regular Maven signal even though they are not declared with `@Test` in this repository. Some integration tests create nested `allure-results` fixtures containing deliberately failed sample data, so regular agent and CI runs must pass `--results-dir target/allure-results` instead of using unrestricted discovery.
 
-The root suite supports Maven's `-Dtest=ClassName` or `-Dtest=ClassName#method` selectors for Surefire and `-Dit.test=ClassName` for Failsafe. The compatibility runner supports `-Dtest=JenkinsCompatibilitySmokeTest` and standard JUnit 5 method selectors through Surefire.
+The root suite supports Maven's `-Dtest=ClassName` or `-Dtest=ClassName#method` selectors for Surefire and `-Dit.test=ClassName` for Failsafe. The compatibility runner supports `-Dtest=JenkinsCompatibilitySmokeTest` and standard JUnit 5 method selectors through Surefire. Its S3 scenario is opt-in via `-Ps3-compat -Dtest=S3ArtifactManagerCompatibilityTest`; follow `compat/README.md` for the pinned topology and latency contract.
 
 ## Run Profiles
 
@@ -116,7 +117,7 @@ npx --yes allure@3 agent --rerun-latest --rerun-preset unsuccessful \
 
 ## Inspecting CI Evidence
 
-The build workflow retains `allure-results-build` as an Allure dump and generates the `allure-report` artifact in an always-run report job. Report plugins, grouping, and conditional Allure Service access are configured in `allurerc.mjs`. When the `ALLURE_SERVICE_TOKEN` GitHub Actions secret is available, the same report generation command also publishes the report to Allure Service. Fork pull requests, where repository secrets are unavailable, still retain the downloadable dump and report artifacts. Compatibility jobs retain `compat-<version>-allure3-dump`.
+The build workflow retains `allure-results-build` as an Allure dump and generates the `allure-report` artifact in an always-run report job. Report plugins, grouping, and conditional Allure Service access are configured in `allurerc.mjs`. When the `ALLURE_SERVICE_TOKEN` GitHub Actions secret is available, the same report generation command also publishes the report to Allure Service. Fork pull requests, where repository secrets are unavailable, still retain the downloadable dump and report artifacts. Compatibility jobs retain `compat-<version>-allure3-dump`; the dedicated S3 job retains `compat-2.528.3-s3-allure3-dump`.
 
 Inspect downloaded artifacts before trying to reproduce a CI-only failure:
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,11 +91,15 @@
       <artifactId>commons-lang3-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+    </dependency>
+    <dependency>
       <groupId>de.schlichtherle.truezip</groupId>
       <artifactId>truezip-driver-zip</artifactId>
       <version>${truezip.version}</version>
       <exclusions>
-        <!-- Provided by Jenkins core -->
+        <!-- Supplied directly so the remote ZIP reader can use it from the plugin class loader. -->
         <exclusion>
           <groupId>org.apache.commons</groupId>
           <artifactId>commons-compress</artifactId>

--- a/src/main/java/org/allurereport/jenkins/AllureReportBuildAction.java
+++ b/src/main/java/org/allurereport/jenkins/AllureReportBuildAction.java
@@ -68,11 +68,8 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
 
     private static final String ALLURE_REPORT = "allure-report";
     private static final String CACHE_CONTROL = "Cache-Control";
-    private static final String CACHE_CONTROL_NO_CACHE = "no-cache, no-store, must-revalidate";
-    private static final String CACHE_CONTROL_POST_CHECK = "post-check=0, pre-check=0";
-    private static final String HEADER_PRAGMA = "Pragma";
-    private static final String HEADER_PRAGMA_NO_CACHE = "no-cache";
-    private static final String HEADER_EXPIRES = "Expires";
+    private static final String CACHE_CONTROL_IMMUTABLE = "private, max-age=31536000, immutable";
+    private static final String CACHE_CONTROL_REVALIDATE = "private, no-cache";
     private static final String HASH_404 = "#404";
     private static final String WAS_ATTACHED_TO_BOTH = "%s was attached to both %s and %s";
     private static final String HEADER_CONTENT_SECURITY_POLICY = "Content-Security-Policy";
@@ -282,7 +279,13 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
 
         final AllureReportArchiveSource archiveSource = AllureReportArchiveSourceFactory.forRun(run);
         if (archiveSource.exists()) {
-            return new ArchiveReportBrowser(archiveSource, reportDirName, reportDirectoryUnderBuild.getRemote());
+            final boolean buildScopedUrl = request.findAncestorObject(Run.class) != null;
+            return new ArchiveReportBrowser(
+                    archiveSource,
+                    reportDirName,
+                    reportDirectoryUnderBuild.getRemote(),
+                    buildScopedUrl
+            );
         }
         archiveSource.close();
 
@@ -531,13 +534,16 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
         private final AllureReportArchiveSource source;
         private final String reportPath;
         private final String reportDirectoryPath;
+        private final boolean buildScopedUrl;
 
         ArchiveReportBrowser(final AllureReportArchiveSource source,
                              final String reportPath,
-                             final String reportDirectoryPath) {
+                             final String reportDirectoryPath,
+                             final boolean buildScopedUrl) {
             this.source = source;
             this.reportPath = reportPath;
             this.reportDirectoryPath = reportDirectoryPath;
+            this.buildScopedUrl = buildScopedUrl;
         }
 
         @Override
@@ -556,10 +562,10 @@ public class AllureReportBuildAction implements BuildBadgeAction, RunAction2, Si
                 }
 
                 rsp.setHeader(HEADER_X_CONTENT_TYPE_OPTIONS, HEADER_NOSNIFF);
-                rsp.setHeader(CACHE_CONTROL, CACHE_CONTROL_NO_CACHE);
-                rsp.addHeader(CACHE_CONTROL, CACHE_CONTROL_POST_CHECK);
-                rsp.setHeader(HEADER_PRAGMA, HEADER_PRAGMA_NO_CACHE);
-                rsp.setDateHeader(HEADER_EXPIRES, 0);
+                rsp.setHeader(
+                        CACHE_CONTROL,
+                        buildScopedUrl ? CACHE_CONTROL_IMMUTABLE : CACHE_CONTROL_REVALIDATE
+                );
 
                 final String rest = normalizeRestOfPath(req, rsp);
                 if (rest == null) {

--- a/src/main/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSource.java
+++ b/src/main/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSource.java
@@ -22,21 +22,30 @@ import jenkins.util.VirtualFile;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * {@link AllureReportArchiveSource} implementation that reads from an artifact stored via
  * Jenkins {@link ArtifactManager} / {@link VirtualFile}.
  *
  * <p>This implementation does <em>not</em> require the archive to be present as a local
- * file on the master node Ã¢ it delegates all I/O to the {@link VirtualFile} API, which
+ * file on the Jenkins controller—it delegates all I/O to the {@link VirtualFile} API, which
  * may transparently read from S3, Azure Blob Storage, or any other pluggable back-end.
  *
  * <p>Because {@link VirtualFile} streams are opened on demand and closed by the caller,
  * this class itself holds no persistent resources and {@link #close()} is a no-op.
  */
 public final class ArtifactManagerArchiveSource implements AllureReportArchiveSource {
+
+    private static final Logger LOGGER = Logger.getLogger(ArtifactManagerArchiveSource.class.getName());
+    private static final int MAX_WARNED_FALLBACKS = 256;
+    private static final Map<String, Boolean> WARNED_FALLBACKS =
+            new LinkedHashMap<>(MAX_WARNED_FALLBACKS, 0.75F, true);
 
     private final Run<?, ?> run;
 
@@ -74,7 +83,12 @@ public final class ArtifactManagerArchiveSource implements AllureReportArchiveSo
             throw new NoSuchElementException("allure-report.zip not found in artifact store for run: "
                     + run.getFullDisplayName());
         }
-        return ZipEntryInputStream.open(zipBlob.open(), entryPath);
+        try {
+            return RemoteZipArchive.openEntry(zipBlob, run.getExternalizableId(), entryPath);
+        } catch (RemoteZipAccessException exception) {
+            warnAboutSequentialFallback(exception);
+            return ZipEntryInputStream.open(zipBlob.open(), entryPath);
+        }
     }
 
     @Override
@@ -95,7 +109,12 @@ public final class ArtifactManagerArchiveSource implements AllureReportArchiveSo
         if (!zipBlob.exists()) {
             return new ArrayList<>();
         }
-        return ZipEntryInputStream.listEntries(zipBlob.open(), prefix);
+        try {
+            return RemoteZipArchive.listEntries(zipBlob, run.getExternalizableId(), prefix);
+        } catch (RemoteZipAccessException exception) {
+            warnAboutSequentialFallback(exception);
+            return ZipEntryInputStream.listEntries(zipBlob.open(), prefix);
+        }
     }
 
     @Override
@@ -105,13 +124,53 @@ public final class ArtifactManagerArchiveSource implements AllureReportArchiveSo
 
     private VirtualFile getArtifactRoot() {
         if (artifactRoot == null) {
-            final ArtifactManager manager = run.getArtifactManager();
-            if (manager == null) {
-                return null;
-            }
-            artifactRoot = manager.root();
+            artifactRoot = run.getArtifactManager().root();
         }
         return artifactRoot;
+    }
+
+    private void warnAboutSequentialFallback(final RemoteZipAccessException exception) {
+        final String reason = safeFailureReason(exception);
+        final String warningKey = run.getRootDir().getAbsolutePath()
+                + '\n' + run.getStartTimeInMillis() + '\n' + reason;
+        if (!markFallbackWarning(warningKey)) {
+            return;
+        }
+
+        LOGGER.log(Level.WARNING, "[Allure] Cannot use HTTP byte ranges for allure-report.zip of build "
+                + run.getExternalizableId() + ": " + reason
+                + ". Falling back to sequential ZIP streaming. Each report asset request may read the archive "
+                + "from the beginning, so the report can load slowly. Verify that the artifact storage and any "
+                + "reverse proxy return HTTP 206 and a valid Content-Range header for Range requests. This warning "
+                + "is logged once per build and failure reason.");
+    }
+
+    private static boolean markFallbackWarning(final String warningKey) {
+        synchronized (WARNED_FALLBACKS) {
+            if (WARNED_FALLBACKS.get(warningKey) != null) {
+                return false;
+            }
+            WARNED_FALLBACKS.put(warningKey, Boolean.TRUE);
+            if (WARNED_FALLBACKS.size() > MAX_WARNED_FALLBACKS) {
+                final String oldestKey = WARNED_FALLBACKS.keySet().iterator().next();
+                WARNED_FALLBACKS.remove(oldestKey);
+            }
+            return true;
+        }
+    }
+
+    private static String safeFailureReason(final RemoteZipAccessException exception) {
+        String reason = null;
+        Throwable cause = exception;
+        while (cause != null) {
+            if (cause instanceof RemoteZipAccessException
+                    && cause.getMessage() != null
+                    && !cause.getMessage().isBlank()) {
+                reason = cause.getMessage();
+            }
+            cause = cause.getCause();
+        }
+        return reason == null || reason.isBlank() ? "unknown byte-range access error" : reason;
     }
 
     private static void collectEntries(final VirtualFile dir,

--- a/src/main/java/org/allurereport/jenkins/utils/HttpRangeReader.java
+++ b/src/main/java/org/allurereport/jenkins/utils/HttpRangeReader.java
@@ -1,0 +1,190 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.utils;
+
+import hudson.ProxyConfiguration;
+import jenkins.util.VirtualFile;
+
+import java.io.EOFException;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class HttpRangeReader {
+
+    private static final int CONNECT_TIMEOUT_MILLIS = 15_000;
+    private static final int READ_TIMEOUT_MILLIS = 30_000;
+    private static final String PREMATURE_EOF = "Remote ZIP range ended before all bytes were read";
+    private static final String HEADER_ACCEPT_ENCODING = "Accept-Encoding";
+    private static final String HEADER_CONTENT_RANGE = "Content-Range";
+    private static final String HEADER_RANGE = "Range";
+    private static final Pattern CONTENT_RANGE = Pattern.compile(
+            "bytes (\\d+)-(\\d+)/(\\d+)",
+            Pattern.CASE_INSENSITIVE
+    );
+
+    private final VirtualFile file;
+    private final long size;
+
+    HttpRangeReader(final VirtualFile file, final long size) {
+        this.file = file;
+        this.size = size;
+    }
+
+    byte[] readRange(final long start, final int length) throws IOException {
+        final byte[] result = new byte[length];
+        int offset = 0;
+        try (InputStream input = openRange(start, length)) {
+            while (offset < result.length) {
+                final int read = input.read(result, offset, result.length - offset);
+                if (read < 0) {
+                    throw new EOFException(PREMATURE_EOF);
+                }
+                offset += read;
+            }
+        }
+        return result;
+    }
+
+    InputStream openRange(final long start, final long length) throws IOException {
+        if (length == 0) {
+            return InputStream.nullInputStream();
+        }
+        if (start < 0 || length < 0 || start > size || length > size - start) {
+            throw new RemoteZipAccessException("Requested range is outside the remote ZIP");
+        }
+
+        final URL url = file.toExternalURL();
+        if (url == null) {
+            throw new RemoteZipAccessException("Artifact manager does not expose an external ZIP URL");
+        }
+
+        final URLConnection rawConnection = ProxyConfiguration.open(url);
+        if (!(rawConnection instanceof HttpURLConnection)) {
+            throw new RemoteZipAccessException("External ZIP URL does not use HTTP");
+        }
+
+        final long end = start + length - 1;
+        final HttpURLConnection connection = (HttpURLConnection) rawConnection;
+        try {
+            connection.setConnectTimeout(CONNECT_TIMEOUT_MILLIS);
+            connection.setReadTimeout(READ_TIMEOUT_MILLIS);
+            connection.setInstanceFollowRedirects(true);
+            connection.setUseCaches(false);
+            connection.setRequestProperty(HEADER_ACCEPT_ENCODING, "identity");
+            connection.setRequestProperty(HEADER_RANGE, "bytes=" + start + "-" + end);
+
+            final int status = connection.getResponseCode();
+            if (status != HttpURLConnection.HTTP_PARTIAL) {
+                closeResponse(connection, status);
+                throw new RemoteZipAccessException("Artifact storage does not support HTTP byte ranges");
+            }
+            validateContentRange(connection.getHeaderField(HEADER_CONTENT_RANGE), start, end);
+            return new RangeResponseInputStream(connection.getInputStream(), connection, length);
+        } catch (IOException | RuntimeException exception) {
+            connection.disconnect();
+            throw exception;
+        }
+    }
+
+    private void validateContentRange(final String header,
+                                      final long expectedStart,
+                                      final long expectedEnd) throws RemoteZipAccessException {
+        final Matcher matcher = header == null ? null : CONTENT_RANGE.matcher(header);
+        if (matcher == null || !matcher.matches()) {
+            throw new RemoteZipAccessException("Artifact storage returned an invalid Content-Range header");
+        }
+        try {
+            final long actualStart = Long.parseLong(matcher.group(1));
+            final long actualEnd = Long.parseLong(matcher.group(2));
+            final long actualSize = Long.parseLong(matcher.group(3));
+            if (actualStart != expectedStart || actualEnd != expectedEnd || actualSize != size) {
+                throw new RemoteZipAccessException("Artifact storage returned an unexpected byte range");
+            }
+        } catch (NumberFormatException exception) {
+            throw new RemoteZipAccessException("Artifact storage returned an invalid byte range", exception);
+        }
+    }
+
+    private static void closeResponse(final HttpURLConnection connection,
+                                      final int status) throws IOException {
+        final InputStream response = status >= HttpURLConnection.HTTP_BAD_REQUEST
+                ? connection.getErrorStream() : connection.getInputStream();
+        if (response != null) {
+            response.close();
+        }
+    }
+
+    private static final class RangeResponseInputStream extends FilterInputStream {
+
+        private final HttpURLConnection connection;
+        private long remaining;
+
+        RangeResponseInputStream(final InputStream input,
+                                 final HttpURLConnection connection,
+                                 final long remaining) {
+            super(input);
+            this.connection = connection;
+            this.remaining = remaining;
+        }
+
+        @Override
+        public int read() throws IOException {
+            if (remaining == 0) {
+                return -1;
+            }
+            final int result = super.read();
+            if (result < 0) {
+                throw new EOFException(PREMATURE_EOF);
+            }
+            remaining--;
+            return result;
+        }
+
+        @Override
+        public int read(final byte[] buffer, final int offset, final int length) throws IOException {
+            Objects.checkFromIndexSize(offset, length, buffer.length);
+            if (length == 0) {
+                return 0;
+            }
+            if (remaining == 0) {
+                return -1;
+            }
+            final int allowed = (int) Math.min(length, remaining);
+            final int result = super.read(buffer, offset, allowed);
+            if (result < 0) {
+                throw new EOFException(PREMATURE_EOF);
+            }
+            remaining -= result;
+            return result;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                super.close();
+            } finally {
+                connection.disconnect();
+            }
+        }
+    }
+}

--- a/src/main/java/org/allurereport/jenkins/utils/RemoteZipAccessException.java
+++ b/src/main/java/org/allurereport/jenkins/utils/RemoteZipAccessException.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.utils;
+
+import java.io.IOException;
+
+final class RemoteZipAccessException extends IOException {
+
+    private static final long serialVersionUID = 1L;
+
+    RemoteZipAccessException(final String message) {
+        super(message);
+    }
+
+    RemoteZipAccessException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/org/allurereport/jenkins/utils/RemoteZipArchive.java
+++ b/src/main/java/org/allurereport/jenkins/utils/RemoteZipArchive.java
@@ -1,0 +1,145 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.utils;
+
+import jenkins.util.VirtualFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+
+final class RemoteZipArchive {
+
+    private static final int MAX_CACHED_ARCHIVES = 8;
+    private static final String INDEX_FAILURE = "Unable to read the remote ZIP index";
+    private static final String RANGE_FAILURE = "Unable to use byte ranges for the remote ZIP";
+    private static final Map<String, CompletableFuture<RemoteZipIndex>> INDEX_CACHE =
+            new LinkedHashMap<>(MAX_CACHED_ARCHIVES, 0.75F, true);
+
+    private RemoteZipArchive() {
+    }
+
+    static InputStream openEntry(final VirtualFile file,
+                                 final String archiveId,
+                                 final String entryPath) throws IOException {
+        try {
+            final long archiveSize = file.length();
+            final RemoteZipIndex index = index(file, archiveSize, cacheKey(file, archiveId, archiveSize));
+            final RemoteZipIndex.Entry entry = index.get(entryPath);
+            if (entry == null) {
+                throw new NoSuchElementException("Entry not found in remote ZIP: " + entryPath);
+            }
+            return RemoteZipEntryInputStream.open(file, archiveSize, entry);
+        } catch (IOException exception) {
+            throw new RemoteZipAccessException(RANGE_FAILURE, exception);
+        }
+    }
+
+    static List<String> listEntries(final VirtualFile file,
+                                    final String archiveId,
+                                    final String prefix) throws IOException {
+        try {
+            final long archiveSize = file.length();
+            return index(file, archiveSize, cacheKey(file, archiveId, archiveSize)).list(prefix);
+        } catch (IOException exception) {
+            throw new RemoteZipAccessException(RANGE_FAILURE, exception);
+        }
+    }
+
+    @SuppressWarnings("PMD.CompareObjectsWithEquals")
+    private static RemoteZipIndex index(final VirtualFile file,
+                                        final long archiveSize,
+                                        final String cacheKey) throws RemoteZipAccessException {
+        final CompletableFuture<RemoteZipIndex> candidate = new CompletableFuture<>();
+        final CompletableFuture<RemoteZipIndex> future = cachedFuture(cacheKey, candidate);
+        if (future == candidate) {
+            loadIndex(file, archiveSize, cacheKey, future);
+        }
+        return awaitIndex(future);
+    }
+
+    private static CompletableFuture<RemoteZipIndex> cachedFuture(
+            final String cacheKey,
+            final CompletableFuture<RemoteZipIndex> candidate) {
+        synchronized (INDEX_CACHE) {
+            final CompletableFuture<RemoteZipIndex> cached = INDEX_CACHE.get(cacheKey);
+            if (cached == null) {
+                INDEX_CACHE.put(cacheKey, candidate);
+                trimCache();
+                return candidate;
+            }
+            return cached;
+        }
+    }
+
+    private static void loadIndex(final VirtualFile file,
+                                  final long archiveSize,
+                                  final String cacheKey,
+                                  final CompletableFuture<RemoteZipIndex> future) {
+        try {
+            future.complete(RemoteZipIndex.load(file, archiveSize));
+        } catch (RemoteZipAccessException exception) {
+            future.completeExceptionally(exception);
+            removeFailedIndex(cacheKey, future);
+        } catch (IOException | RuntimeException exception) {
+            future.completeExceptionally(new RemoteZipAccessException(INDEX_FAILURE, exception));
+            removeFailedIndex(cacheKey, future);
+        }
+    }
+
+    private static void removeFailedIndex(final String cacheKey,
+                                          final CompletableFuture<RemoteZipIndex> future) {
+        synchronized (INDEX_CACHE) {
+            INDEX_CACHE.remove(cacheKey, future);
+        }
+    }
+
+    private static RemoteZipIndex awaitIndex(final CompletableFuture<RemoteZipIndex> future)
+            throws RemoteZipAccessException {
+        try {
+            return future.get();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new RemoteZipAccessException("Interrupted while reading the remote ZIP index", exception);
+        } catch (ExecutionException exception) {
+            final Throwable cause = exception.getCause();
+            if (cause instanceof RemoteZipAccessException) {
+                throw (RemoteZipAccessException) cause;
+            }
+            throw new RemoteZipAccessException(INDEX_FAILURE, exception);
+        }
+    }
+
+    private static String cacheKey(final VirtualFile file,
+                                   final String archiveId,
+                                   final long archiveSize) throws IOException {
+        return archiveId + '\n' + file.toURI() + '\n' + archiveSize + '\n' + file.lastModified();
+    }
+
+    private static void trimCache() {
+        final Iterator<String> keys = INDEX_CACHE.keySet().iterator();
+        while (INDEX_CACHE.size() > MAX_CACHED_ARCHIVES && keys.hasNext()) {
+            keys.next();
+            keys.remove();
+        }
+    }
+}

--- a/src/main/java/org/allurereport/jenkins/utils/RemoteZipEntryInputStream.java
+++ b/src/main/java/org/allurereport/jenkins/utils/RemoteZipEntryInputStream.java
@@ -1,0 +1,142 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.utils;
+
+import jenkins.util.VirtualFile;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.zip.CRC32;
+import java.util.zip.Inflater;
+import java.util.zip.InflaterInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipException;
+
+final class RemoteZipEntryInputStream {
+
+    private RemoteZipEntryInputStream() {
+    }
+
+    @SuppressWarnings("PMD.CloseResource")
+    static InputStream open(final VirtualFile file,
+                            final long archiveSize,
+                            final RemoteZipIndex.Entry entry) throws IOException {
+        if (entry.isEncrypted()) {
+            throw new RemoteZipAccessException("Encrypted remote ZIP entries are not supported");
+        }
+        if (entry.getMethod() != ZipEntry.STORED && entry.getMethod() != ZipEntry.DEFLATED) {
+            throw new RemoteZipAccessException("Remote ZIP entry uses an unsupported compression method");
+        }
+
+        final HttpRangeReader reader = new HttpRangeReader(file, archiveSize);
+        final long dataOffset = entry.resolveDataOffset(reader, archiveSize);
+        final InputStream compressed = reader.openRange(dataOffset, entry.getCompressedSize());
+        try {
+            final InputStream content = entry.getMethod() == ZipEntry.DEFLATED
+                    ? new RawInflaterInputStream(compressed) : compressed;
+            return new ValidatingInputStream(content, entry);
+        } catch (RuntimeException exception) {
+            compressed.close();
+            throw exception;
+        }
+    }
+
+    private static final class RawInflaterInputStream extends InflaterInputStream {
+
+        private final Inflater rawInflater;
+
+        RawInflaterInputStream(final InputStream input) {
+            this(input, new Inflater(true));
+        }
+
+        private RawInflaterInputStream(final InputStream input, final Inflater inflater) {
+            super(input, inflater);
+            this.rawInflater = inflater;
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                super.close();
+            } finally {
+                rawInflater.end();
+            }
+        }
+    }
+
+    private static final class ValidatingInputStream extends FilterInputStream {
+
+        private final String entryName;
+        private final long expectedSize;
+        private final long expectedCrc;
+        private final CRC32 crc = new CRC32();
+        private long bytesRead;
+        private boolean validated;
+
+        ValidatingInputStream(final InputStream input, final RemoteZipIndex.Entry entry) {
+            super(input);
+            this.entryName = entry.getName();
+            this.expectedSize = entry.getSize();
+            this.expectedCrc = entry.getCrc();
+        }
+
+        @Override
+        public int read() throws IOException {
+            final int result = super.read();
+            if (result < 0) {
+                validateEnd();
+            } else {
+                crc.update(result);
+                bytesRead++;
+                validateMaximumSize();
+            }
+            return result;
+        }
+
+        @Override
+        public int read(final byte[] buffer, final int offset, final int length) throws IOException {
+            final int result = super.read(buffer, offset, length);
+            if (result < 0) {
+                validateEnd();
+            } else if (result > 0) {
+                crc.update(buffer, offset, result);
+                bytesRead += result;
+                validateMaximumSize();
+            }
+            return result;
+        }
+
+        private void validateMaximumSize() throws ZipException {
+            if (bytesRead > expectedSize) {
+                throw new ZipException("Remote ZIP entry exceeds its declared size: " + entryName);
+            }
+        }
+
+        private void validateEnd() throws ZipException {
+            if (validated) {
+                return;
+            }
+            validated = true;
+            if (bytesRead != expectedSize) {
+                throw new ZipException("Remote ZIP entry has an unexpected size: " + entryName);
+            }
+            if (expectedCrc >= 0 && crc.getValue() != expectedCrc) {
+                throw new ZipException("Remote ZIP entry failed its CRC check: " + entryName);
+            }
+        }
+    }
+}

--- a/src/main/java/org/allurereport/jenkins/utils/RemoteZipIndex.java
+++ b/src/main/java/org/allurereport/jenkins/utils/RemoteZipIndex.java
@@ -1,0 +1,271 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.utils;
+
+import jenkins.util.VirtualFile;
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.NonWritableChannelException;
+import java.nio.channels.SeekableByteChannel;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class RemoteZipIndex {
+
+    private final Map<String, Entry> entries;
+
+    private RemoteZipIndex(final Map<String, Entry> entries) {
+        this.entries = Collections.unmodifiableMap(entries);
+    }
+
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
+    static RemoteZipIndex load(final VirtualFile file, final long size) throws IOException {
+        if (size <= 0) {
+            throw new RemoteZipAccessException("Remote ZIP has no readable content");
+        }
+
+        final HttpRangeReader reader = new HttpRangeReader(file, size);
+        final Map<String, Entry> entries = new LinkedHashMap<>();
+        try (SeekableByteChannel channel = new PagedChannel(reader, size);
+             ZipFile zip = ZipFile.builder()
+                     .setSeekableByteChannel(channel)
+                     .setIgnoreLocalFileHeader(true)
+                     .get()) {
+            final Enumeration<ZipArchiveEntry> zipEntries = zip.getEntries();
+            while (zipEntries.hasMoreElements()) {
+                final ZipArchiveEntry zipEntry = zipEntries.nextElement();
+                if (!zipEntry.isDirectory()) {
+                    entries.putIfAbsent(zipEntry.getName(), new Entry(zipEntry));
+                }
+            }
+        }
+        return new RemoteZipIndex(entries);
+    }
+
+    Entry get(final String path) {
+        return entries.get(path);
+    }
+
+    List<String> list(final String prefix) {
+        final List<String> result = new ArrayList<>();
+        for (String name : entries.keySet()) {
+            if (name.startsWith(prefix)) {
+                result.add(name);
+            }
+        }
+        return result;
+    }
+
+    static final class Entry {
+
+        private static final int LOCAL_HEADER_LENGTH = 30;
+        private static final int LOCAL_HEADER_SIGNATURE = 0x04034b50;
+        private static final long UNKNOWN_OFFSET = -1L;
+
+        private final String name;
+        private final long localHeaderOffset;
+        private final long compressedSize;
+        private final long size;
+        private final long crc;
+        private final int method;
+        private final boolean encrypted;
+        private long dataOffset = UNKNOWN_OFFSET;
+
+        Entry(final ZipArchiveEntry entry) {
+            this.name = entry.getName();
+            this.localHeaderOffset = entry.getLocalHeaderOffset();
+            this.compressedSize = entry.getCompressedSize();
+            this.size = entry.getSize();
+            this.crc = entry.getCrc();
+            this.method = entry.getMethod();
+            this.encrypted = entry.getGeneralPurposeBit().usesEncryption();
+        }
+
+        String getName() {
+            return name;
+        }
+
+        long getCompressedSize() {
+            return compressedSize;
+        }
+
+        long getSize() {
+            return size;
+        }
+
+        long getCrc() {
+            return crc;
+        }
+
+        int getMethod() {
+            return method;
+        }
+
+        boolean isEncrypted() {
+            return encrypted;
+        }
+
+        long resolveDataOffset(final HttpRangeReader reader,
+                               final long archiveSize) throws IOException {
+            synchronized (this) {
+                if (dataOffset == UNKNOWN_OFFSET) {
+                    dataOffset = readDataOffset(reader, archiveSize);
+                }
+                return dataOffset;
+            }
+        }
+
+        private long readDataOffset(final HttpRangeReader reader,
+                                    final long archiveSize) throws IOException {
+            if (localHeaderOffset < 0 || compressedSize < 0 || size < 0) {
+                throw new RemoteZipAccessException("Remote ZIP entry has invalid size metadata");
+            }
+            final byte[] header = reader.readRange(localHeaderOffset, LOCAL_HEADER_LENGTH);
+            if (littleEndianInt(header, 0) != LOCAL_HEADER_SIGNATURE) {
+                throw new RemoteZipAccessException("Remote ZIP entry has an invalid local header");
+            }
+            final int nameLength = littleEndianShort(header, 26);
+            final int extraLength = littleEndianShort(header, 28);
+            final long resolved = localHeaderOffset + LOCAL_HEADER_LENGTH + nameLength + extraLength;
+            if (resolved < localHeaderOffset
+                    || resolved > archiveSize
+                    || compressedSize > archiveSize - resolved) {
+                throw new RemoteZipAccessException("Remote ZIP entry data is outside the archive");
+            }
+            return resolved;
+        }
+
+        private static int littleEndianInt(final byte[] bytes, final int offset) {
+            return ByteBuffer.wrap(bytes, offset, Integer.BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN)
+                    .getInt();
+        }
+
+        private static int littleEndianShort(final byte[] bytes, final int offset) {
+            return Short.toUnsignedInt(ByteBuffer.wrap(bytes, offset, Short.BYTES)
+                    .order(ByteOrder.LITTLE_ENDIAN)
+                    .getShort());
+        }
+    }
+
+    private static final class PagedChannel implements SeekableByteChannel {
+
+        private static final int PAGE_SIZE = 64 * 1024;
+
+        private final HttpRangeReader reader;
+        private final long archiveSize;
+        private final Map<Long, byte[]> pages = new HashMap<>();
+        private long currentPosition;
+        private boolean open = true;
+
+        PagedChannel(final HttpRangeReader reader, final long size) {
+            this.reader = reader;
+            this.archiveSize = size;
+        }
+
+        @Override
+        public int read(final ByteBuffer target) throws IOException {
+            ensureOpen();
+            if (!target.hasRemaining()) {
+                return 0;
+            }
+            if (currentPosition >= archiveSize) {
+                return -1;
+            }
+            final int initialRemaining = target.remaining();
+            while (target.hasRemaining() && currentPosition < archiveSize) {
+                final long pageNumber = currentPosition / PAGE_SIZE;
+                final byte[] page = page(pageNumber);
+                final int pageOffset = (int) (currentPosition % PAGE_SIZE);
+                final int length = Math.min(target.remaining(), page.length - pageOffset);
+                target.put(page, pageOffset, length);
+                currentPosition += length;
+            }
+            return initialRemaining - target.remaining();
+        }
+
+        @Override
+        public int write(final ByteBuffer source) throws IOException {
+            throw new NonWritableChannelException();
+        }
+
+        @Override
+        public long position() throws IOException {
+            ensureOpen();
+            return currentPosition;
+        }
+
+        @Override
+        public SeekableByteChannel position(final long newPosition) throws IOException {
+            ensureOpen();
+            if (newPosition < 0) {
+                throw new IllegalArgumentException("Position must not be negative");
+            }
+            currentPosition = newPosition;
+            return this;
+        }
+
+        @Override
+        public long size() throws IOException {
+            ensureOpen();
+            return archiveSize;
+        }
+
+        @Override
+        public SeekableByteChannel truncate(final long newSize) throws IOException {
+            throw new NonWritableChannelException();
+        }
+
+        @Override
+        public boolean isOpen() {
+            return open;
+        }
+
+        @Override
+        public void close() {
+            open = false;
+            pages.clear();
+        }
+
+        private byte[] page(final long pageNumber) throws IOException {
+            final byte[] cached = pages.get(pageNumber);
+            if (cached != null) {
+                return cached;
+            }
+            final long start = pageNumber * PAGE_SIZE;
+            final int length = (int) Math.min(PAGE_SIZE, archiveSize - start);
+            final byte[] loaded = reader.readRange(start, length);
+            pages.put(pageNumber, loaded);
+            return loaded;
+        }
+
+        private void ensureOpen() throws ClosedChannelException {
+            if (!open) {
+                throw new ClosedChannelException();
+            }
+        }
+    }
+}

--- a/src/test/java/org/allurereport/jenkins/AllureReportBuildActionIT.java
+++ b/src/test/java/org/allurereport/jenkins/AllureReportBuildActionIT.java
@@ -56,12 +56,14 @@ public class AllureReportBuildActionIT {
     private static final String SLASH = "/";
     private static final String INDEX_FILE = "index.html";
     private static final String ALLURE_PATH = "allure/";
+    private static final String HEADER_CACHE_CONTROL = "Cache-Control";
     private static final String HEADER_CONTENT_SECURITY_POLICY = "Content-Security-Policy";
     private static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";
     private static final String CONTENT_DISPOSITION_ATTACHMENT = "attachment";
     private static final String INDEX_ENTRY = REPORT_DIR + SLASH + INDEX_FILE;
     private static final String INDEX_PATH = ALLURE_PATH + INDEX_FILE;
     private static final String ENCODED_ASSET_ENTRY = REPORT_DIR + "/data/space file.txt";
+    private static final String ENCODED_ASSET_PATH = "data/space%20file.txt";
     private static final String ENCODED_ASSET_CONTENT = "decoded asset";
     private static final String HTML_ATTACHMENT_PATH = "data/attachments/foo.html";
     private static final String PLUGIN_ENTRYPOINT_PATH = "awesome/index.html";
@@ -87,6 +89,12 @@ public class AllureReportBuildActionIT {
     private static final String CSP_BASE_URI_NONE = "base-uri 'none'";
     private static final String CSP_FORM_ACTION_NONE = "form-action 'none'";
     private static final String CSP_OBJECT_SRC_NONE = "object-src 'none'";
+    private static final String CACHE_PRIVATE = "private";
+    private static final String CACHE_IMMUTABLE = "immutable";
+    private static final String CACHE_ONE_YEAR = "max-age=31536000";
+    private static final String CACHE_NO_CACHE = "no-cache";
+    private static final String CACHE_NO_STORE = "no-store";
+    private static final String CACHE_PUBLIC = "public";
 
     @ClassRule
     public static BuildWatcher buildWatcher = new BuildWatcher();
@@ -124,6 +132,41 @@ public class AllureReportBuildActionIT {
     }
 
     @Test
+    public void shouldCacheReportAssetsAtNumberedBuildUrls() throws Exception {
+        final FreeStyleBuild build = buildArchivedReportWithEntries(Map.of(
+                INDEX_ENTRY, EMPTY_INDEX_CONTENT,
+                ENCODED_ASSET_ENTRY, ENCODED_ASSET_CONTENT
+        ), jRule, REPORT_DIR);
+        final JenkinsRule.WebClient webClient = jRule.createWebClient().withJavaScriptEnabled(false);
+
+        final WebResponse response = webClient.loadWebResponse(
+                new WebRequest(new URL(jRule.getURL(), build.getUrl() + ALLURE_PATH + ENCODED_ASSET_PATH))
+        );
+
+        assertThat(response.getResponseHeaderValue(HEADER_CACHE_CONTROL))
+                .contains(CACHE_PRIVATE, CACHE_ONE_YEAR, CACHE_IMMUTABLE)
+                .doesNotContain(CACHE_NO_CACHE, CACHE_NO_STORE, CACHE_PUBLIC);
+    }
+
+    @Test
+    public void shouldRevalidateReportAssetsAtMovingProjectUrls() throws Exception {
+        final FreeStyleBuild build = buildArchivedReportWithEntries(Map.of(
+                INDEX_ENTRY, EMPTY_INDEX_CONTENT,
+                ENCODED_ASSET_ENTRY, ENCODED_ASSET_CONTENT
+        ), jRule, REPORT_DIR);
+        final JenkinsRule.WebClient webClient = jRule.createWebClient().withJavaScriptEnabled(false);
+
+        final WebResponse response = webClient.loadWebResponse(new WebRequest(new URL(
+                jRule.getURL(),
+                build.getProject().getUrl() + ALLURE_PATH + ENCODED_ASSET_PATH
+        )));
+
+        assertThat(response.getResponseHeaderValue(HEADER_CACHE_CONTROL))
+                .contains(CACHE_PRIVATE, CACHE_NO_CACHE)
+                .doesNotContain(CACHE_ONE_YEAR, CACHE_IMMUTABLE, CACHE_NO_STORE, CACHE_PUBLIC);
+    }
+
+    @Test
     public void shouldDownloadIndexFromArchivedZip() throws Exception {
         final FreeStyleBuild build = buildSingleReportBuild();
         final JenkinsRule.WebClient webClient = jRule.createWebClient().withJavaScriptEnabled(false);
@@ -147,7 +190,7 @@ public class AllureReportBuildActionIT {
         final JenkinsRule.WebClient webClient = jRule.createWebClient().withJavaScriptEnabled(false);
 
         final WebResponse response = webClient.loadWebResponse(
-                new WebRequest(new URL(jRule.getURL(), build.getUrl() + ALLURE_PATH + "data/space%20file.txt"))
+                new WebRequest(new URL(jRule.getURL(), build.getUrl() + ALLURE_PATH + ENCODED_ASSET_PATH))
         );
 
         assertThat(response.getStatusCode()).isEqualTo(200);

--- a/src/test/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSourceLoggingTest.java
+++ b/src/test/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSourceLoggingTest.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.utils;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ArtifactManagerArchiveSourceLoggingTest {
+
+    private static final String LARGE_ENTRY = "allure-report/data/leading.bin";
+    private static final String REPORT_ENTRY = "allure-report/index.html";
+    private static final String REPORT_CONTENT = "<html>report</html>";
+
+    @Rule
+    public JenkinsRule jRule = new JenkinsRule();
+
+    @Rule
+    public LoggerRule logger = new LoggerRule()
+            .record(ArtifactManagerArchiveSource.class, Level.WARNING)
+            .capture(100)
+            .quiet();
+
+    @Test
+    public void sequentialFallbackWarningIsActionableAndDeduplicated() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+        final byte[] archive = ZipTestArchive.createWithLargeLeadingEntry(
+                LARGE_ENTRY,
+                64 * 1024,
+                REPORT_ENTRY,
+                REPORT_CONTENT
+        );
+
+        try (RangeAwareArtifactManager manager = new RangeAwareArtifactManager(archive, false)) {
+            manager.install(build);
+
+            assertReportEntry(build);
+            assertReportEntry(build);
+
+            assertThat(logger.getRecords())
+                    .filteredOn(record -> record.getLevel().equals(Level.WARNING))
+                    .filteredOn(record -> record.getMessage().contains("Falling back to sequential ZIP streaming"))
+                    .singleElement()
+                    .extracting(LogRecord::getMessage)
+                    .asString()
+                    .contains(build.getExternalizableId())
+                    .contains("Artifact storage does not support HTTP byte ranges")
+                    .contains("Each report asset request may read the archive from the beginning")
+                    .contains("HTTP 206")
+                    .contains("once per build and failure reason");
+        }
+    }
+
+    private void assertReportEntry(final FreeStyleBuild build) throws Exception {
+        try (ArtifactManagerArchiveSource source = new ArtifactManagerArchiveSource(build);
+             InputStream inputStream = source.openEntry(REPORT_ENTRY)) {
+            assertThat(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8))
+                    .isEqualTo(REPORT_CONTENT);
+        }
+    }
+}

--- a/src/test/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSourceTest.java
+++ b/src/test/java/org/allurereport/jenkins/utils/ArtifactManagerArchiveSourceTest.java
@@ -24,6 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
@@ -48,6 +49,8 @@ public class ArtifactManagerArchiveSourceTest {
     private static final String ZIP_HISTORY = "{\"zip\":true}";
     private static final String EMPTY_OBJECT = "{}";
     private static final String EMPTY_ARRAY = "[]";
+    private static final String LARGE_ENTRY = "allure-report/data/large-prefix.bin";
+    private static final int LARGE_ENTRY_SIZE = 2 * 1024 * 1024;
 
     @Rule
     public JenkinsRule jRule = new JenkinsRule();
@@ -75,6 +78,76 @@ public class ArtifactManagerArchiveSourceTest {
              InputStream inputStream = source.openEntry(HISTORY_ENTRY)) {
             assertThat(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8))
                     .isEqualTo(ZIP_HISTORY);
+        }
+    }
+
+    @Test
+    public void openEntryUsesByteRangesInsteadOfScanningLargeArchivePrefix() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+        final byte[] archive = largeRemoteArchive();
+
+        try (RangeAwareArtifactManager manager = new RangeAwareArtifactManager(archive, true)) {
+            manager.install(build);
+
+            try (ArtifactManagerArchiveSource source = new ArtifactManagerArchiveSource(build);
+                 InputStream inputStream = source.openEntry(HISTORY_ENTRY)) {
+                assertThat(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8))
+                        .isEqualTo(ZIP_HISTORY);
+            }
+
+            assertThat(manager.getFullStreamBytesRead())
+                    .as("bytes consumed from the remote full-object stream")
+                    .isZero();
+            assertThat(manager.getRangeBytesServed())
+                    .as("bytes transferred through HTTP ranges")
+                    .isLessThan(manager.getArchiveSize() / 4L);
+        }
+    }
+
+    @Test
+    public void listEntriesReusesRangeBackedIndexAcrossSourceInstances() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+
+        try (RangeAwareArtifactManager manager = new RangeAwareArtifactManager(largeRemoteArchive(), true)) {
+            manager.install(build);
+
+            try (ArtifactManagerArchiveSource source = new ArtifactManagerArchiveSource(build)) {
+                assertThat(source.listEntries(HISTORY_PREFIX)).containsExactly(HISTORY_ENTRY);
+            }
+            final int requestsAfterFirstList = manager.getRangeRequests();
+
+            try (ArtifactManagerArchiveSource source = new ArtifactManagerArchiveSource(build)) {
+                assertThat(source.listEntries(HISTORY_PREFIX)).containsExactly(HISTORY_ENTRY);
+            }
+
+            assertThat(requestsAfterFirstList).isPositive();
+            assertThat(manager.getRangeRequests())
+                    .as("range requests after reusing the cached central directory")
+                    .isEqualTo(requestsAfterFirstList);
+            assertThat(manager.getFullStreamBytesRead()).isZero();
+            assertThat(manager.getRangeBytesServed()).isLessThan(manager.getArchiveSize() / 4L);
+        }
+    }
+
+    @Test
+    public void openEntryFallsBackWhenArtifactStorageDoesNotSupportRanges() throws Exception {
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+
+        try (RangeAwareArtifactManager manager = new RangeAwareArtifactManager(largeRemoteArchive(), false)) {
+            manager.install(build);
+
+            try (ArtifactManagerArchiveSource source = new ArtifactManagerArchiveSource(build);
+                 InputStream inputStream = source.openEntry(HISTORY_ENTRY)) {
+                assertThat(new String(inputStream.readAllBytes(), StandardCharsets.UTF_8))
+                        .isEqualTo(ZIP_HISTORY);
+            }
+
+            assertThat(manager.getRangeRequests()).isPositive();
+            assertThat(manager.getFullStreamBytesRead()).isGreaterThan(LARGE_ENTRY_SIZE);
+            assertThat(manager.getRangeBytesServed()).isZero();
         }
     }
 
@@ -198,6 +271,15 @@ public class ArtifactManagerArchiveSourceTest {
                         AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP,
                         AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP
                 )
+        );
+    }
+
+    private byte[] largeRemoteArchive() throws IOException {
+        return ZipTestArchive.createWithLargeLeadingEntry(
+                LARGE_ENTRY,
+                LARGE_ENTRY_SIZE,
+                HISTORY_ENTRY,
+                ZIP_HISTORY
         );
     }
 

--- a/src/test/java/org/allurereport/jenkins/utils/RangeAwareArtifactManager.java
+++ b/src/test/java/org/allurereport/jenkins/utils/RangeAwareArtifactManager.java
@@ -1,0 +1,308 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.utils;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpServer;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.Run;
+import jenkins.model.ArtifactManager;
+import jenkins.util.VirtualFile;
+
+import java.io.FileNotFoundException;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URL;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Test-only artifact manager whose archive can be read through either a full stream or HTTP byte ranges.
+ */
+final class RangeAwareArtifactManager extends ArtifactManager implements AutoCloseable {
+
+    private static final String PATH_SEPARATOR = "/";
+    private static final String LOOPBACK_HOST = "127.0.0.1";
+    private static final String CONTENT_RANGE_HEADER = "Content-Range";
+    private static final Pattern RANGE_HEADER = Pattern.compile("bytes=(\\d+)-(\\d+)");
+    private static final String ARCHIVE_PATH = PATH_SEPARATOR
+            + AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP;
+
+    private final byte[] archive;
+    private final boolean rangeSupported;
+    private final AtomicLong fullStreamBytesRead = new AtomicLong();
+    private final AtomicLong rangeBytesServed = new AtomicLong();
+    private final AtomicInteger rangeRequests = new AtomicInteger();
+    private final HttpServer server;
+    private final URL archiveUrl;
+    private final VirtualFile root;
+
+    RangeAwareArtifactManager(final byte[] archive, final boolean rangeSupported) throws IOException {
+        this.archive = archive.clone();
+        this.rangeSupported = rangeSupported;
+        this.server = HttpServer.create(new InetSocketAddress(LOOPBACK_HOST, 0), 0);
+        this.server.createContext(ARCHIVE_PATH, this::serveArchive);
+        this.server.start();
+        this.archiveUrl = new URL("http", LOOPBACK_HOST, server.getAddress().getPort(), ARCHIVE_PATH);
+        this.root = new TestVirtualFile(this, FileKind.ROOT, "artifacts", null);
+    }
+
+    void install(final FreeStyleBuild build) throws Exception {
+        final java.lang.reflect.Field artifactManager = Run.class.getDeclaredField("artifactManager");
+        artifactManager.setAccessible(true);
+        onLoad(build);
+        artifactManager.set(build, this);
+    }
+
+    long getFullStreamBytesRead() {
+        return fullStreamBytesRead.get();
+    }
+
+    long getRangeBytesServed() {
+        return rangeBytesServed.get();
+    }
+
+    int getRangeRequests() {
+        return rangeRequests.get();
+    }
+
+    int getArchiveSize() {
+        return archive.length;
+    }
+
+    @Override
+    public void onLoad(final Run<?, ?> run) {
+    }
+
+    @Override
+    public void archive(final FilePath workspace,
+                        final Launcher launcher,
+                        final BuildListener listener,
+                        final Map<String, String> artifacts) {
+        throw new UnsupportedOperationException("Not used in tests");
+    }
+
+    @Override
+    public boolean delete() {
+        return false;
+    }
+
+    @Override
+    public VirtualFile root() {
+        return root;
+    }
+
+    @Override
+    public void close() {
+        server.stop(0);
+    }
+
+    private void serveArchive(final HttpExchange exchange) throws IOException {
+        try {
+            exchange.getResponseHeaders().set("Content-Type", "application/zip");
+            exchange.getResponseHeaders().set("Accept-Ranges", "bytes");
+            final String range = exchange.getRequestHeaders().getFirst("Range");
+            if (!rangeSupported || range == null) {
+                if (range != null) {
+                    rangeRequests.incrementAndGet();
+                }
+                exchange.sendResponseHeaders(200, archive.length);
+                exchange.getResponseBody().write(archive);
+                return;
+            }
+
+            rangeRequests.incrementAndGet();
+            final Matcher matcher = RANGE_HEADER.matcher(range);
+            if (!matcher.matches()) {
+                sendRangeNotSatisfiable(exchange);
+                return;
+            }
+
+            final long requestedStart = Long.parseLong(matcher.group(1));
+            final long requestedEnd = Long.parseLong(matcher.group(2));
+            if (requestedStart < 0 || requestedStart >= archive.length || requestedEnd < requestedStart) {
+                sendRangeNotSatisfiable(exchange);
+                return;
+            }
+
+            final int start = Math.toIntExact(requestedStart);
+            final int end = Math.toIntExact(Math.min(requestedEnd, archive.length - 1L));
+            final int length = end - start + 1;
+            rangeBytesServed.addAndGet(length);
+            exchange.getResponseHeaders().set(
+                    CONTENT_RANGE_HEADER,
+                    "bytes " + start + "-" + end + PATH_SEPARATOR + archive.length
+            );
+            exchange.sendResponseHeaders(206, length);
+            exchange.getResponseBody().write(archive, start, length);
+        } catch (IOException clientDisconnected) {
+            // A range capability probe intentionally closes a full response as soon as it sees HTTP 200.
+        } finally {
+            exchange.close();
+        }
+    }
+
+    private void sendRangeNotSatisfiable(final HttpExchange exchange) throws IOException {
+        exchange.getResponseHeaders().set(CONTENT_RANGE_HEADER, "bytes */" + archive.length);
+        exchange.sendResponseHeaders(416, -1);
+    }
+
+    private enum FileKind {
+        ROOT,
+        ARCHIVE,
+        MISSING
+    }
+
+    private static final class TestVirtualFile extends VirtualFile {
+
+        private static final long serialVersionUID = 1L;
+
+        private final RangeAwareArtifactManager manager;
+        private final FileKind kind;
+        private final String name;
+        private final TestVirtualFile parent;
+
+        TestVirtualFile(final RangeAwareArtifactManager manager,
+                        final FileKind kind,
+                        final String name,
+                        final TestVirtualFile parent) {
+            this.manager = manager;
+            this.kind = kind;
+            this.name = name;
+            this.parent = parent;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public URI toURI() {
+            return URI.create("memory:/allure-test/"
+                    + kind.name().toLowerCase() + PATH_SEPARATOR + name);
+        }
+
+        @Override
+        public URL toExternalURL() {
+            return kind == FileKind.ARCHIVE ? manager.archiveUrl : null;
+        }
+
+        @Override
+        public VirtualFile getParent() {
+            return parent;
+        }
+
+        @Override
+        public boolean isDirectory() {
+            return kind == FileKind.ROOT;
+        }
+
+        @Override
+        public boolean isFile() {
+            return kind == FileKind.ARCHIVE;
+        }
+
+        @Override
+        public boolean exists() {
+            return kind != FileKind.MISSING;
+        }
+
+        @Override
+        public VirtualFile[] list() {
+            if (kind != FileKind.ROOT) {
+                return new VirtualFile[0];
+            }
+            return new VirtualFile[]{child(AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP)};
+        }
+
+        @Override
+        public VirtualFile child(final String childName) {
+            if (kind == FileKind.ROOT
+                    && AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP.equals(childName)) {
+                return new TestVirtualFile(manager, FileKind.ARCHIVE, childName, this);
+            }
+            return new TestVirtualFile(manager, FileKind.MISSING, childName, this);
+        }
+
+        @Override
+        public long length() {
+            return kind == FileKind.ARCHIVE ? manager.archive.length : 0;
+        }
+
+        @Override
+        public long lastModified() {
+            return kind == FileKind.ARCHIVE ? 1L : 0L;
+        }
+
+        @Override
+        public boolean canRead() {
+            return exists();
+        }
+
+        @Override
+        public InputStream open() throws IOException {
+            if (kind != FileKind.ARCHIVE) {
+                throw new FileNotFoundException(toString());
+            }
+            return new CountingInputStream(manager.archive, manager.fullStreamBytesRead);
+        }
+    }
+
+    private static final class CountingInputStream extends FilterInputStream {
+
+        private final AtomicLong bytesRead;
+
+        CountingInputStream(final byte[] data, final AtomicLong bytesRead) {
+            super(new java.io.ByteArrayInputStream(data));
+            this.bytesRead = bytesRead;
+        }
+
+        @Override
+        public int read() throws IOException {
+            final int result = super.read();
+            if (result >= 0) {
+                bytesRead.incrementAndGet();
+            }
+            return result;
+        }
+
+        @Override
+        public int read(final byte[] buffer, final int offset, final int length) throws IOException {
+            final int result = super.read(buffer, offset, length);
+            if (result > 0) {
+                bytesRead.addAndGet(result);
+            }
+            return result;
+        }
+
+        @Override
+        public long skip(final long amount) throws IOException {
+            final long skipped = super.skip(amount);
+            bytesRead.addAndGet(skipped);
+            return skipped;
+        }
+    }
+}

--- a/src/test/java/org/allurereport/jenkins/utils/ZipTestArchive.java
+++ b/src/test/java/org/allurereport/jenkins/utils/ZipTestArchive.java
@@ -1,0 +1,55 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.utils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+final class ZipTestArchive {
+
+    private ZipTestArchive() {
+    }
+
+    static byte[] createWithLargeLeadingEntry(final String largeEntryName,
+                                              final int largeEntrySize,
+                                              final String entryName,
+                                              final String entryContent) throws IOException {
+        final byte[] largeContent = new byte[largeEntrySize];
+        final CRC32 crc = new CRC32();
+        crc.update(largeContent);
+
+        final ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ZipOutputStream zip = new ZipOutputStream(output)) {
+            final ZipEntry largeEntry = new ZipEntry(largeEntryName);
+            largeEntry.setMethod(ZipEntry.STORED);
+            largeEntry.setSize(largeContent.length);
+            largeEntry.setCompressedSize(largeContent.length);
+            largeEntry.setCrc(crc.getValue());
+            zip.putNextEntry(largeEntry);
+            zip.write(largeContent);
+            zip.closeEntry();
+
+            zip.putNextEntry(new ZipEntry(entryName));
+            zip.write(entryContent.getBytes(StandardCharsets.UTF_8));
+            zip.closeEntry();
+        }
+        return output.toByteArray();
+    }
+}


### PR DESCRIPTION
Allure reports stored through remote artifact managers such as S3 and Azure now load individual report files without repeatedly downloading and scanning the entire ZIP archive. This keeps large reports responsive while allowing the archive to remain off the Jenkins controller.

Numbered-build report assets now use immutable browser caching, while moving project URLs revalidate to avoid stale content. Storage or proxy configurations that do not support byte ranges retain the existing streaming fallback and produce an actionable controller warning explaining the slowdown and required HTTP range behavior.

fixes #454