### PR TITLE
Use latest Java 11-compatible plugin parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>6.2153.vcf31911d10c4</version>
+    <version>4.88</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
## Summary

- replace the incompatible 6.x plugin-parent selection with 4.88, the latest 4.x release
- preserve this plugin's Java 11 build/runtime compatibility and existing Maven 3.9.1 wrapper
- keep source, tests, and workflows unchanged while still upgrading the parent from 4.74 to 4.88 when combined with #459

## Root cause

Plugin parent `6.2153.vcf31911d10c4` requires Maven 3.9.6+ and Java 17. This repository builds and publishes with Java 11 and its wrapper uses Maven 3.9.1. The exact Dependabot head therefore fails while Maven is building the project model:

```text
Unknown packaging: hpi @ line 15, column 14
```

Updating the wrapper and workflows would make CI green by silently dropping Java 11 compatibility. Parent 4.88 instead retains `maven.compiler.release=11` and requires Maven 3.8.1+, so it is compatible with the repository's current contract.

## Verification

All comparison runs used Corretto 11.0.32.1 and the repository's exact CI command:

```console
./mvnw -B -ntp package
```

- exact parent `73f8a6c7415fd75264897f8e4f93fd041e5d5945`: passed in 2m 43s
- exact Dependabot head `cdc6978ad927c91e28db0d3d6f8c1f46fac5e2d4`: failed during project-model loading with `Unknown packaging: hpi`
- this change: passed in 2m 52s
- parent and candidate each ran 110 tests with 0 failures, 0 errors, and 0 skips
- candidate also passed bytecode/dependency enforcement, Checkstyle, PMD, SpotBugs, Spotless, license generation, JAR packaging, and HPI packaging
- `git diff --check`: passed
