### PR TITLE
Add a local storage option for Allure reports

### DIFF
--- a/src/main/java/org/allurereport/jenkins/AllureReportPublisher.java
+++ b/src/main/java/org/allurereport/jenkins/AllureReportPublisher.java
@@ -41,6 +41,7 @@ import org.allurereport.jenkins.callables.FindByGlob;
 import org.allurereport.jenkins.config.AllureReportConfig;
 import org.allurereport.jenkins.config.PropertyConfig;
 import org.allurereport.jenkins.config.ReportBuildPolicy;
+import org.allurereport.jenkins.config.ReportStorage;
 import org.allurereport.jenkins.config.ResultPolicy;
 import org.allurereport.jenkins.config.ResultsConfig;
 import org.allurereport.jenkins.exception.AllurePluginException;
@@ -660,8 +661,6 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
                                     final FilePath workspace,
                                     final TaskListener listener,
                                     final Launcher launcher) throws IOException, InterruptedException {
-        listener.getLogger().println("Archiving Allure report via ArtifactManager…");
-
         final String reportDirPath = getReport();
         final FilePath reportPathWs = workspace.child(reportDirPath);
 
@@ -692,11 +691,11 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
             artifacts.put(SUMMARY_ARTIFACT_NAME, SUMMARY_ARTIFACT_NAME);
         }
 
-        final BuildListener buildListener =
-            (listener instanceof BuildListener) ? (BuildListener) listener : new BuildListenerAdapter(listener);
-
-        run.pickArtifactManager().archive(workspace, launcher, buildListener, artifacts);
-        listener.getLogger().println("Allure artifact archived via ArtifactManager.");
+        if (ReportStorage.LOCAL_ON_CONTROLLER.equals(getDescriptor().getReportStorage())) {
+            storeAllureArtifactLocally(workspace, archiveDir, artifacts, listener);
+        } else {
+            archiveAllureArtifact(run, workspace, launcher, artifacts, listener);
+        }
 
         final FilePath zipPath = workspace.child(REPORT_ARCHIVE_NAME);
         if (zipPath.exists()) {
@@ -707,6 +706,31 @@ public class AllureReportPublisher extends Recorder implements SimpleBuildStep, 
         if (summaryPath.exists()) {
             summaryPath.delete();
         }
+    }
+
+    private void storeAllureArtifactLocally(final FilePath workspace,
+                                            final FilePath archiveDir,
+                                            final Map<String, String> artifacts,
+                                            final TaskListener listener) throws IOException, InterruptedException {
+        listener.getLogger().println("Storing Allure report locally on Jenkins controller…");
+        archiveDir.mkdirs();
+        for (Map.Entry<String, String> artifact : artifacts.entrySet()) {
+            workspace.child(artifact.getValue()).copyTo(archiveDir.child(artifact.getKey()));
+        }
+        listener.getLogger().println("Allure report stored locally on Jenkins controller.");
+    }
+
+    private void archiveAllureArtifact(final Run<?, ?> run,
+                                       final FilePath workspace,
+                                       final Launcher launcher,
+                                       final Map<String, String> artifacts,
+                                       final TaskListener listener) throws IOException, InterruptedException {
+        listener.getLogger().println("Archiving Allure report via ArtifactManager…");
+        final BuildListener buildListener =
+            (listener instanceof BuildListener) ? (BuildListener) listener : new BuildListenerAdapter(listener);
+
+        run.pickArtifactManager().archive(workspace, launcher, buildListener, artifacts);
+        listener.getLogger().println("Allure artifact archived via ArtifactManager.");
     }
 
     private void createSummaryJson(final FilePath workspace,

--- a/src/main/java/org/allurereport/jenkins/AllureReportPublisherDescriptor.java
+++ b/src/main/java/org/allurereport/jenkins/AllureReportPublisherDescriptor.java
@@ -32,6 +32,7 @@ import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.allurereport.jenkins.config.PropertyConfig;
 import org.allurereport.jenkins.config.ReportBuildPolicy;
+import org.allurereport.jenkins.config.ReportStorage;
 import org.allurereport.jenkins.config.ResultPolicy;
 import org.allurereport.jenkins.tools.Allure3Installation;
 import org.allurereport.jenkins.tools.AllureCommandlineDirectInstaller;
@@ -59,10 +60,12 @@ import java.util.stream.Collectors;
 public class AllureReportPublisherDescriptor extends BuildStepDescriptor<Publisher> {
 
     private static final String PROPERTIES = "properties";
+    private static final String REPORT_STORAGE = "reportStorage";
     private static final String NEWLINE = "\n";
     private static final int SINGLE_INSTALLATION = 1;
     private final Object quickSetupLock = new Object();
     private List<PropertyConfig> properties;
+    private ReportStorage reportStorage;
 
     public AllureReportPublisherDescriptor() {
         super(AllureReportPublisher.class);
@@ -82,6 +85,19 @@ public class AllureReportPublisherDescriptor extends BuildStepDescriptor<Publish
 
     public void setProperties(final List<PropertyConfig> properties) {
         this.properties = properties;
+    }
+
+    public ReportStorage getReportStorage() {
+        return reportStorage == null ? ReportStorage.ARTIFACT_MANAGER : reportStorage;
+    }
+
+    public void setReportStorage(final ReportStorage reportStorage) {
+        this.reportStorage = reportStorage;
+    }
+
+    @SuppressWarnings("unused")
+    public ReportStorage[] getReportStorages() {
+        return ReportStorage.values();
     }
 
     @Override
@@ -113,6 +129,11 @@ public class AllureReportPublisherDescriptor extends BuildStepDescriptor<Publish
     public boolean configure(final StaplerRequest req,
         final JSONObject json) throws FormException {
         try {
+            final String reportStorageValue = json.optString(
+                REPORT_STORAGE, ReportStorage.ARTIFACT_MANAGER.getValue()
+            );
+            final ReportStorage submittedReportStorage = ReportStorage.valueOf(reportStorageValue);
+
             if (json.has(PROPERTIES)) {
                 final String jsonProperties = JSONObject.fromObject(json).get(PROPERTIES).toString();
                 final ObjectMapper mapper = new ObjectMapper()
@@ -121,9 +142,10 @@ public class AllureReportPublisherDescriptor extends BuildStepDescriptor<Publish
                 final List<PropertyConfig> properties = mapper.readValue(jsonProperties,
                     new TypeReference<List<PropertyConfig>>() { });
                 setProperties(properties);
-                save();
             }
-        } catch (IOException e) {
+            setReportStorage(submittedReportStorage);
+            save();
+        } catch (IOException | IllegalArgumentException e) {
             return false;
         }
         return true;

--- a/src/main/java/org/allurereport/jenkins/config/ReportStorage.java
+++ b/src/main/java/org/allurereport/jenkins/config/ReportStorage.java
@@ -1,0 +1,37 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins.config;
+
+public enum ReportStorage {
+
+    ARTIFACT_MANAGER("Artifact Manager"),
+
+    LOCAL_ON_CONTROLLER("Local on Jenkins controller");
+
+    private final String title;
+
+    ReportStorage(final String title) {
+        this.title = title;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getValue() {
+        return name();
+    }
+}

--- a/src/main/resources/org/allurereport/jenkins/AllureReportPublisher/global.jelly
+++ b/src/main/resources/org/allurereport/jenkins/AllureReportPublisher/global.jelly
@@ -4,6 +4,16 @@
 
     <f:section title="Allure Report">
 
+        <f:entry title="Allure report storage" field="reportStorage"
+                 description="Artifact Manager is used by default. Selecting Local on Jenkins controller disables Artifact Manager use for Allure reports and keeps them only on the Jenkins controller node. Other build artifacts continue using the configured Artifact Manager.">
+            <select class="setting-input" name="reportStorage">
+                <j:forEach var="storage" items="${descriptor.getReportStorages()}">
+                    <f:option selected="${storage.equals(descriptor.getReportStorage())}"
+                              value="${storage.getValue()}">${storage.getTitle()}</f:option>
+                </j:forEach>
+            </select>
+        </f:entry>
+
         <f:entry title="${%Properties}" field="properties">
             <f:repeatable var="properties" items="${descriptor.getProperties()}">
                 <table>

--- a/src/main/resources/org/allurereport/jenkins/AllureReportPublisher/help-reportStorage.html
+++ b/src/main/resources/org/allurereport/jenkins/AllureReportPublisher/help-reportStorage.html
@@ -1,0 +1,16 @@
+<div>
+    <p>
+        <strong>Artifact Manager</strong> is the default and stores the Allure report using the Artifact Manager
+        configured for the build.
+    </p>
+    <p>
+        <strong>Local on Jenkins controller</strong> disables Artifact Manager use for Allure reports and keeps them
+        only in the build directory on the Jenkins controller node. This can be used with Artifact Managers that do
+        not preserve artifacts across multiple archive operations. Other build artifacts continue using the configured
+        Artifact Manager.
+    </p>
+    <p>
+        Local storage consumes disk space on the Jenkins controller. When a remote Artifact Manager is active,
+        artifact-only cleanup might not remove the locally stored Allure report; deleting the build removes it.
+    </p>
+</div>

--- a/src/test/java/org/allurereport/jenkins/AllureReportPublisherDescriptorTest.java
+++ b/src/test/java/org/allurereport/jenkins/AllureReportPublisherDescriptorTest.java
@@ -20,6 +20,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import static org.allurereport.jenkins.config.ReportStorage.ARTIFACT_MANAGER;
+import static org.allurereport.jenkins.config.ReportStorage.LOCAL_ON_CONTROLLER;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AllureReportPublisherDescriptorTest {
@@ -69,6 +71,20 @@ public class AllureReportPublisherDescriptorTest {
                 .setInstallations(installation(FIRST), installation(SECOND));
 
         assertThat(descriptor.getDefaultCommandlineInstallation()).isNull();
+    }
+
+    @Test
+    public void reportStorageDefaultsToArtifactManager() {
+        assertThat(descriptor().getReportStorage()).isEqualTo(ARTIFACT_MANAGER);
+    }
+
+    @Test
+    public void localReportStorageSurvivesGlobalConfigRoundtrip() throws Exception {
+        descriptor().setReportStorage(LOCAL_ON_CONTROLLER);
+
+        jRule.configRoundtrip();
+
+        assertThat(descriptor().getReportStorage()).isEqualTo(LOCAL_ON_CONTROLLER);
     }
 
     private AllureReportPublisherDescriptor descriptor() {

--- a/src/test/java/org/allurereport/jenkins/LocalReportStorageIT.java
+++ b/src/test/java/org/allurereport/jenkins/LocalReportStorageIT.java
@@ -1,0 +1,217 @@
+/*
+ *  Copyright 2016-2023 Qameta Software OÜ
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.allurereport.jenkins;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Run;
+import hudson.tasks.ArtifactArchiver;
+import jenkins.model.ArtifactManager;
+import jenkins.model.ArtifactManagerConfiguration;
+import jenkins.model.ArtifactManagerFactory;
+import jenkins.model.ArtifactManagerFactoryDescriptor;
+import jenkins.util.VirtualFile;
+import org.allurereport.jenkins.config.ReportStorage;
+import org.allurereport.jenkins.testdata.TestUtils;
+import org.allurereport.jenkins.utils.AllureReportArchiveSource;
+import org.allurereport.jenkins.utils.AllureReportArchiveSourceFactory;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestBuilder;
+import org.jvnet.hudson.test.TestExtension;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.allurereport.jenkins.testdata.TestUtils.createAllurePublisher;
+import static org.allurereport.jenkins.testdata.TestUtils.getSimpleFileScm;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LocalReportStorageIT {
+
+    private static final String RESULTS_DIR = "allure-results";
+    private static final String SAMPLE_PASSED = "sample-testsuite.xml";
+    private static final String SAMPLE_RESULTS_PATH = RESULTS_DIR + "/sample-testsuite.xml";
+    private static final String REPORT_PATH = "allure-report";
+    private static final String REPORT_INDEX = REPORT_PATH + "/index.html";
+    private static final String OTHER_ARTIFACT = "other.txt";
+    private static final String REMOTE_ARTIFACTS = "remote-artifacts";
+    private static final String SUMMARY_ARTIFACT = "allure-summary.json";
+
+    @Rule
+    public JenkinsRule jRule = new JenkinsRule();
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void storesAllureLocallyWithoutCallingArtifactManagerAgain() throws Exception {
+        configureSingleArchiveArtifactManager();
+        final String jdk = TestUtils.getJdk(jRule).getName();
+        final String commandline = TestUtils.getAllureCommandline(jRule, folder).getName();
+        final AllureReportPublisherDescriptor descriptor = jRule.jenkins
+                .getDescriptorByType(AllureReportPublisherDescriptor.class);
+        descriptor.setReportStorage(ReportStorage.LOCAL_ON_CONTROLLER);
+
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        project.setScm(getSimpleFileScm(SAMPLE_PASSED, SAMPLE_RESULTS_PATH));
+        project.getBuildersList().add(new OtherArtifactBuilder());
+        project.getPublishersList().add(new ArtifactArchiver(OTHER_ARTIFACT));
+        project.getPublishersList().add(createAllurePublisher(jdk, commandline, RESULTS_DIR));
+
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+
+        assertThat(SingleArchiveArtifactManagerFactory.archiveCalls()).isEqualTo(1);
+        assertThat(build.getArtifactManager().root().child(OTHER_ARTIFACT).exists()).isTrue();
+        assertThat(build.getArtifactManager().root()
+                .child(AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP).exists()).isFalse();
+        assertThat(new File(build.getArtifactsDir(), AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP))
+                .isFile();
+        assertThat(new File(build.getArtifactsDir(), SUMMARY_ARTIFACT)).isFile();
+        jRule.assertLogContains("Allure report stored locally on Jenkins controller.", build);
+
+        try (AllureReportArchiveSource source = AllureReportArchiveSourceFactory.forRun(build)) {
+            final List<String> entries = source.listEntries(REPORT_PATH);
+            assertThat(entries).contains(REPORT_INDEX);
+        }
+    }
+
+    @Test
+    public void archivesAllureThroughArtifactManagerByDefault() throws Exception {
+        configureSingleArchiveArtifactManager();
+        final String jdk = TestUtils.getJdk(jRule).getName();
+        final String commandline = TestUtils.getAllureCommandline(jRule, folder).getName();
+
+        final FreeStyleProject project = jRule.createFreeStyleProject();
+        project.setScm(getSimpleFileScm(SAMPLE_PASSED, SAMPLE_RESULTS_PATH));
+        project.getPublishersList().add(createAllurePublisher(jdk, commandline, RESULTS_DIR));
+
+        final FreeStyleBuild build = jRule.buildAndAssertSuccess(project);
+
+        assertThat(SingleArchiveArtifactManagerFactory.archiveCalls()).isEqualTo(1);
+        assertThat(build.getArtifactManager().root()
+                .child(AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP).exists()).isTrue();
+        assertThat(build.getArtifactManager().root().child(SUMMARY_ARTIFACT).exists()).isTrue();
+        assertThat(new File(build.getArtifactsDir(), AllureReportArchiveSourceFactory.ALLURE_REPORT_ZIP))
+                .doesNotExist();
+        jRule.assertLogContains("Allure artifact archived via ArtifactManager.", build);
+
+        try (AllureReportArchiveSource source = AllureReportArchiveSourceFactory.forRun(build)) {
+            final List<String> entries = source.listEntries(REPORT_PATH);
+            assertThat(entries).contains(REPORT_INDEX);
+        }
+    }
+
+    private void configureSingleArchiveArtifactManager() {
+        SingleArchiveArtifactManagerFactory.reset();
+        ArtifactManagerConfiguration.get().getArtifactManagerFactories()
+                .add(new SingleArchiveArtifactManagerFactory());
+    }
+
+    public static class SingleArchiveArtifactManagerFactory extends ArtifactManagerFactory {
+
+        private static final AtomicInteger ARCHIVE_CALLS = new AtomicInteger();
+
+        static void reset() {
+            ARCHIVE_CALLS.set(0);
+        }
+
+        static int archiveCalls() {
+            return ARCHIVE_CALLS.get();
+        }
+
+        @Override
+        public ArtifactManager managerFor(final Run<?, ?> run) {
+            return new SingleArchiveArtifactManager(new File(run.getRootDir(), REMOTE_ARTIFACTS));
+        }
+
+        @TestExtension
+        public static class DescriptorImpl extends ArtifactManagerFactoryDescriptor {
+
+            @Override
+            public String getDisplayName() {
+                return "Single archive Artifact Manager";
+            }
+        }
+
+        private static final class SingleArchiveArtifactManager extends ArtifactManager {
+
+            private final String rootPath;
+
+            SingleArchiveArtifactManager(final File root) {
+                this.rootPath = root.getAbsolutePath();
+            }
+
+            @Override
+            public void onLoad(final Run<?, ?> run) {
+            }
+
+            @Override
+            public void archive(final FilePath workspace,
+                                final Launcher launcher,
+                                final BuildListener listener,
+                                final Map<String, String> artifacts) throws IOException, InterruptedException {
+                final int invocation = ARCHIVE_CALLS.incrementAndGet();
+                if (invocation > 1) {
+                    throw new IOException("Artifact Manager was invoked more than once");
+                }
+
+                final FilePath root = new FilePath(new File(rootPath));
+                root.mkdirs();
+                for (Map.Entry<String, String> artifact : artifacts.entrySet()) {
+                    final FilePath target = root.child(artifact.getKey());
+                    final FilePath parent = target.getParent();
+                    if (parent != null) {
+                        parent.mkdirs();
+                    }
+                    workspace.child(artifact.getValue()).copyTo(target);
+                }
+            }
+
+            @Override
+            public boolean delete() throws IOException {
+                Util.deleteRecursive(new File(rootPath));
+                return true;
+            }
+
+            @Override
+            public VirtualFile root() {
+                return VirtualFile.forFile(new File(rootPath));
+            }
+        }
+    }
+
+    private static final class OtherArtifactBuilder extends TestBuilder {
+
+        @Override
+        public boolean perform(final AbstractBuild<?, ?> build,
+                               final Launcher launcher,
+                               final BuildListener listener) throws IOException, InterruptedException {
+            build.getWorkspace().child(OTHER_ARTIFACT).write("other artifact", "UTF-8");
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Adds a global Allure report storage setting under Manage Jenkins → System. Artifact Manager remains the default, while administrators can select “Local on Jenkins controller” to bypass Artifact Manager for Allure reports and keep them only in each build’s controller directory.

This allows installations using Compress Artifacts or another incompatible Artifact Manager to keep regular build artifacts in remote or compressed storage while Allure reports remain available locally. The setting applies consistently to all builds and includes guidance about controller disk usage and retention.

fixes #467