### PR TITLE
Align the plugin with Java 17 and Jenkins 2.541.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       ALLURE_DUMP_NAME: allure-results-build
-      ALLURE_ENVIRONMENT: ubuntu-jdk-11
+      ALLURE_ENVIRONMENT: ubuntu-jdk-17
     steps:
     - uses: actions/checkout@v7
       with:
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/setup-java@v5
       with:
         distribution: temurin
-        java-version: 11
+        java-version: 17
         cache: 'maven'
     - uses: actions/setup-node@v7
       with:

--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -20,7 +20,7 @@ on:
       jenkins_version:
         description: Jenkins Docker tag or core version to test
         required: true
-        default: '2.462.1'
+        default: '2.541.3'
         type: string
 
 concurrency:
@@ -53,7 +53,7 @@ jobs:
     needs: build-plugin
     timeout-minutes: 45
     env:
-      JENKINS_VERSION: ${{ inputs.jenkins_version || '2.462.1' }}
+      JENKINS_VERSION: ${{ inputs.jenkins_version || '2.541.3' }}
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5
@@ -113,8 +113,8 @@ jobs:
     needs: build-plugin
     timeout-minutes: 45
     env:
-      JENKINS_VERSION: '2.528.3'
-      COMPAT_ID: '2.528.3-s3'
+      JENKINS_VERSION: '2.541.3'
+      COMPAT_ID: '2.541.3-s3'
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'maven'
           server-id: maven.jenkins-ci.org
           server-username: JENKINS_USERNAME

--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,2 +1,2 @@
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.1/apache-maven-3.9.1-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
 wrapperUrl=https://repo.maven.apache.org/maven2/io/takari/maven-wrapper/0.5.6/maven-wrapper-0.5.6.jar

--- a/compat/README.md
+++ b/compat/README.md
@@ -15,9 +15,9 @@ The harness stages Allure results, Surefire reports, Jenkins logs, console outpu
 
 Shared diagnostics are stored as global attachments: the Jenkins controller log, Jenkins initialization and setup scripts, the plugin list, and Maven stdout and stderr. Job-specific Groovy checks, JSON responses, console logs, and report pages remain attached to the test that produced them. Surefire reports stay in the local staging directory and are not duplicated in the dump.
 
-Pull requests run the suite against Jenkins `2.462.1` when plugin, build, workflow, or compatibility-harness files change. A newer commit on the same pull request cancels the superseded run. Use the manual workflow input to test an additional Jenkins version or exact Docker tag.
+Pull requests run the suite against Jenkins `2.541.3` when plugin, build, workflow, or compatibility-harness files change. A newer commit on the same pull request cancels the superseded run. Use the manual workflow input to test an additional Jenkins version or exact Docker tag.
 
-The S3 latency scenario runs as a separate job against Jenkins `2.528.3` and
+The S3 latency scenario runs as a separate job against Jenkins `2.541.3` and
 `artifact-manager-s3:962.v15f7000205fa_`. It creates a 64 MiB incompressible
 report attachment in MinIO, verifies that the report ZIP is remote and that
 `index.html` follows more than 50 MiB of data, then constrains downstream S3
@@ -33,57 +33,57 @@ You need Docker available locally. Build the plugin first so the runner can pick
 ./mvnw -DskipTests clean package
 ./mvnw -q -f compat/jenkins-smoke/pom.xml \
   -Dcompat.rootDir="$(pwd)" \
-  -Dcompat.version=2.462.1 \
+  -Dcompat.version=2.541.3 \
   test
 ```
 
-By default, a bare Jenkins version such as `2.462.1` is normalized to the Docker image tag `2.462.1-lts-jdk17`. If you want to test an exact Docker tag, pass that tag directly via `-Dcompat.version=...`.
+By default, a bare Jenkins version such as `2.541.3` is normalized to the Docker image tag `2.541.3-lts-jdk17`. If you want to test an exact Docker tag, pass that tag directly via `-Dcompat.version=...`.
 
 The main local test output lives in `compat-artifacts/<version>/allure-results`. To reproduce the CI artifact locally, run the suite through the latest Allure 3 CLI from npm (Node.js and npm are required):
 
 ```bash
-export COMPAT_ARTIFACT_ROOT="$(pwd)/compat-artifacts/2.462.1"
+export COMPAT_ARTIFACT_ROOT="$(pwd)/compat-artifacts/2.541.3"
 mkdir -p allure-dumps
 npx --yes allure@3 run \
-  --dump=allure-dumps/compat-2.462.1 \
-  --environment=jenkins-2-462-1 \
+  --dump=allure-dumps/compat-2.541.3 \
+  --environment=jenkins-2-541-3 \
   -- ./mvnw -B -e -ntp -f compat/jenkins-smoke/pom.xml \
     -Dcompat.rootDir="$(pwd)" \
-    -Dcompat.version=2.462.1 \
+    -Dcompat.version=2.541.3 \
     -Dcompat.artifactRoot="$COMPAT_ARTIFACT_ROOT" \
     test
 ```
 
-This creates `allure-dumps/compat-2.462.1.zip`. Generate a report from a downloaded dump with:
+This creates `allure-dumps/compat-2.541.3.zip`. Generate a report from a downloaded dump with:
 
 ```bash
 npx --yes allure@3 generate \
   --config ./allurerc.mjs \
-  --dump=allure-dumps/compat-2.462.1.zip
+  --dump=allure-dumps/compat-2.541.3.zip
 ```
 
 ## S3 Artifact Manager Latency Test
 
 The `s3-compat` Maven profile opts into the Docker-backed S3 scenario and defaults
-to Jenkins `2.528.3`. MinIO and Toxiproxy are pulled automatically; no local S3
+to Jenkins `2.541.3`. MinIO and Toxiproxy are pulled automatically; no local S3
 credentials or service are required. Run it through Allure agent mode so the
 remote archive facts, proxy settings, measured latency, and container logs stay
 reviewable:
 
 ```bash
 npx --yes allure@3 agent \
-  --results-dir "$PWD/compat-artifacts/2.528.3-s3/allure-results" \
-  --goal "Confirm Jenkins 2.528.3 serves a greater-than-50-MiB Allure report from S3 within the constrained-link latency budget" \
+  --results-dir "$PWD/compat-artifacts/2.541.3-s3/allure-results" \
+  --goal "Confirm Jenkins 2.541.3 serves a greater-than-50-MiB Allure report from S3 within the constrained-link latency budget" \
   --expect-test "org.allurereport.jenkins.compat.S3ArtifactManagerCompatibilityTest.shouldServeLargeS3ReportWithinLatencyBudget" \
   -- ./mvnw -B -e -ntp -f compat/jenkins-smoke/pom.xml \
     -Ps3-compat \
     -Dtest=S3ArtifactManagerCompatibilityTest \
     -Dcompat.rootDir="$PWD" \
-    -Dcompat.version=2.528.3 \
-    -Dcompat.artifactRoot="$PWD/compat-artifacts/2.528.3-s3" \
+    -Dcompat.version=2.541.3 \
+    -Dcompat.artifactRoot="$PWD/compat-artifacts/2.541.3-s3" \
     test
 ```
 
 The regular compatibility command leaves this test visibly skipped because the
 profile is disabled. CI stores the opt-in run separately as
-`compat-2.528.3-s3-allure3-dump`.
+`compat-2.541.3-s3-allure3-dump`.

--- a/compat/jenkins-smoke/pom.xml
+++ b/compat/jenkins-smoke/pom.xml
@@ -13,7 +13,7 @@
         <allure.junit5.version>2.29.1</allure.junit5.version>
         <compat.rootDir>${project.basedir}/../..</compat.rootDir>
         <compat.s3.enabled>false</compat.s3.enabled>
-        <compat.version>2.462.1</compat.version>
+        <compat.version>2.541.3</compat.version>
         <compat.artifactRoot>${compat.rootDir}/compat-artifacts/${compat.version}</compat.artifactRoot>
         <jackson.version>2.18.2</jackson.version>
         <junit.jupiter.version>5.11.4</junit.jupiter.version>
@@ -106,7 +106,7 @@
             <id>s3-compat</id>
             <properties>
                 <compat.s3.enabled>true</compat.s3.enabled>
-                <compat.version>2.528.3</compat.version>
+                <compat.version>2.541.3</compat.version>
             </properties>
         </profile>
     </profiles>

--- a/compat/jenkins-smoke/src/test/java/org/allurereport/jenkins/compat/JenkinsCompatibilitySmokeTest.java
+++ b/compat/jenkins-smoke/src/test/java/org/allurereport/jenkins/compat/JenkinsCompatibilitySmokeTest.java
@@ -87,20 +87,23 @@ class JenkinsCompatibilitySmokeTest {
     private static final long POLL_DELAY_MS = 5_000L;
 
     private static final List<String> REQUIRED_PLUGINS_WITHOUT_MATRIX = List.of(
-            "bouncycastle-api:2.30.1.78.1-248.ve27176eb_46cb_",
-            "commons-lang3-api:3.17.0-84.vb_b_938040b_078",
-            "jackson2-api:2.17.0-389.va_5c7e45cd806",
-            "display-url-api:2.204.vf6fddd8a_8b_e9"
+            "bouncycastle-api:2.30.1.84-291.v9f17b_21896e2",
+            "commons-lang3-api:3.20.0-109.ve43756e2d2b_4",
+            "jackson2-api:2.22.2-445.vdc613f1d8012",
+            "display-url-api:2.217.va_6b_de84cc74b_"
     );
 
     private static final List<String> REQUIRED_PLUGINS_WITH_MATRIX = Stream.concat(
             REQUIRED_PLUGINS_WITHOUT_MATRIX.stream(),
             Stream.of(
-                    "matrix-project:839.vff91cd7e3a_b_2",
-                    "workflow-basic-steps:1058.vcb_fc1e3a_21a_9",
-                    "workflow-cps:4009.v0089238351a_9",
-                    "workflow-durable-task-step:1378.v6a_3e903058a_3",
-                    "workflow-job:1436.vfa_244484591f"
+                    "matrix-project:905.vcc6831e8760a_",
+                    "workflow-basic-steps:1098.v808b_fd7f8cf4",
+                    "workflow-cps:4370.v49a_6937566b_6",
+                    "workflow-durable-task-step:1479.v56e587f413a_7",
+                    "workflow-job:1571.1580.v18e46842c125",
+                    "workflow-step-api:724.v538c2362b_dfb_",
+                    "script-security:1412.v7737b_3405f86",
+                    "structs:362.va_b_695ef4fdf9"
             )
     ).toList();
 
@@ -1004,7 +1007,7 @@ class JenkinsCompatibilitySmokeTest {
 
         private static Configuration fromSystemProperties() {
             final Path rootDir = Path.of(System.getProperty("compat.rootDir", ".")).toAbsolutePath().normalize();
-            final String requestedVersion = System.getProperty("compat.version", "2.462.1").trim();
+            final String requestedVersion = System.getProperty("compat.version", "2.541.3").trim();
             final String normalizedImageTag = normalizeJenkinsImageTag(requestedVersion);
             final Path artifactRoot = Path.of(System.getProperty(
                     "compat.artifactRoot",

--- a/compat/jenkins-smoke/src/test/java/org/allurereport/jenkins/compat/S3ArtifactManagerCompatibilityTest.java
+++ b/compat/jenkins-smoke/src/test/java/org/allurereport/jenkins/compat/S3ArtifactManagerCompatibilityTest.java
@@ -105,10 +105,13 @@ class S3ArtifactManagerCompatibilityTest {
     private static final long POLL_DELAY_MILLIS = 2_000L;
 
     private static final List<String> REQUIRED_PLUGINS = List.of(
-            "bouncycastle-api:2.30.1.79-254.vfdb_814e7791e",
-            "commons-lang3-api:3.17.0-84.vb_b_938040b_078",
-            "jackson2-api:2.17.0-389.va_5c7e45cd806",
-            "display-url-api:2.204.vf6fddd8a_8b_e9",
+            "bouncycastle-api:2.30.1.84-291.v9f17b_21896e2",
+            "commons-lang3-api:3.20.0-109.ve43756e2d2b_4",
+            "jackson2-api:2.22.2-445.vdc613f1d8012",
+            "display-url-api:2.217.va_6b_de84cc74b_",
+            "workflow-step-api:724.v538c2362b_dfb_",
+            "script-security:1412.v7737b_3405f86",
+            "structs:362.va_b_695ef4fdf9",
             "artifact-manager-s3:" + ARTIFACT_MANAGER_S3_VERSION
     );
 
@@ -774,7 +777,7 @@ class S3ArtifactManagerCompatibilityTest {
             final Path rootDir = Path.of(System.getProperty("compat.rootDir", "."))
                     .toAbsolutePath()
                     .normalize();
-            final String requestedVersion = System.getProperty("compat.version", "2.528.3").trim();
+            final String requestedVersion = System.getProperty("compat.version", "2.541.3").trim();
             final String normalizedImageTag = normalizeJenkinsImageTag(requestedVersion);
             final Path artifactRoot = Path.of(System.getProperty(
                     "compat.artifactRoot",

--- a/docs/allure-agent-mode.md
+++ b/docs/allure-agent-mode.md
@@ -32,7 +32,7 @@ The `allure@3` selector intentionally floats to the newest Allure 3 release publ
 | Regular unit tests | Maven Surefire + JUnit 4 | `src/test/java/**/*Test.java` | `target/allure-results` | Java and Maven wrapper |
 | Regular integration tests | Maven Failsafe + JUnit 4 | `src/test/java/**/*IT.java` | `target/allure-results` | Jenkins test harness; the build downloads an Allure commandline fixture |
 | Jenkins compatibility smoke | Maven Surefire + JUnit 5/Testcontainers | `compat/jenkins-smoke/src/test/java` | `compat-artifacts/<jenkins-version>/allure-results` | Docker, Java 17, and a built plugin HPI |
-| S3 Artifact Manager compatibility | Maven Surefire + JUnit 5/Testcontainers | `S3ArtifactManagerCompatibilityTest` | `compat-artifacts/2.528.3-s3/allure-results` | Docker, Java 17, a built plugin HPI, and the `s3-compat` profile; MinIO and Toxiproxy images are pulled automatically |
+| S3 Artifact Manager compatibility | Maven Surefire + JUnit 5/Testcontainers | `S3ArtifactManagerCompatibilityTest` | `compat-artifacts/2.541.3-s3/allure-results` | Docker, Java 17, a built plugin HPI, and the `s3-compat` profile; MinIO and Toxiproxy images are pulled automatically |
 
 The regular test adapter is configured in `pom.xml`; its stable result path is configured in `src/test/resources/allure.properties`. The compatibility runner has its own adapter and result path in `compat/jenkins-smoke/pom.xml`.
 
@@ -72,12 +72,12 @@ Build the HPI first, then follow `compat/README.md` for the version-specific Mav
 
 ```bash
 npx --yes allure@3 agent \
-  --results-dir "$PWD/compat-artifacts/2.462.1/allure-results" \
+  --results-dir "$PWD/compat-artifacts/2.541.3/allure-results" \
   --goal "Confirm Jenkins compatibility for the selected Jenkins version" \
   -- ./mvnw -B -e -ntp -f compat/jenkins-smoke/pom.xml \
     -Dcompat.rootDir="$PWD" \
-    -Dcompat.version=2.462.1 \
-    -Dcompat.artifactRoot="$PWD/compat-artifacts/2.462.1" \
+    -Dcompat.version=2.541.3 \
+    -Dcompat.artifactRoot="$PWD/compat-artifacts/2.541.3" \
     test
 ```
 
@@ -117,7 +117,7 @@ npx --yes allure@3 agent --rerun-latest --rerun-preset unsuccessful \
 
 ## Inspecting CI Evidence
 
-The build workflow retains `allure-results-build` as an Allure dump and generates the `allure-report` artifact in an always-run report job. Report plugins, grouping, and conditional Allure Service access are configured in `allurerc.mjs`. When the `ALLURE_SERVICE_TOKEN` GitHub Actions secret is available, the same report generation command also publishes the report to Allure Service. Fork pull requests, where repository secrets are unavailable, still retain the downloadable dump and report artifacts. Compatibility jobs retain `compat-<version>-allure3-dump`; the dedicated S3 job retains `compat-2.528.3-s3-allure3-dump`.
+The build workflow retains `allure-results-build` as an Allure dump and generates the `allure-report` artifact in an always-run report job. Report plugins, grouping, and conditional Allure Service access are configured in `allurerc.mjs`. When the `ALLURE_SERVICE_TOKEN` GitHub Actions secret is available, the same report generation command also publishes the report to Allure Service. Fork pull requests, where repository secrets are unavailable, still retain the downloadable dump and report artifacts. Compatibility jobs retain `compat-<version>-allure3-dump`; the dedicated S3 job retains `compat-2.541.3-s3-allure3-dump`.
 
 Inspect downloaded artifacts before trying to reproduce a CI-only failure:
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.74</version>
+    <version>6.2221.va_045130417c9</version>
     <relativePath />
   </parent>
 
@@ -53,6 +53,7 @@
 
   <properties>
     <allure.version>2.35.3</allure.version>
+    <commons-compress.version>1.28.0</commons-compress.version>
     <spotless-maven-plugin.version>2.43.0</spotless-maven-plugin.version>
     <spotless.skip>false</spotless.skip>
     <spotless.check.skip>false</spotless.check.skip>
@@ -60,11 +61,10 @@
     <spotless.ratchetFrom>origin/main</spotless.ratchetFrom>
     <gitHubRepo>jenkinsci/allure-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.462</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
+    <jenkins.baseline>2.541</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.3</jenkins.version>
     <allureCommandline.version>2.35.1</allureCommandline.version>
     <truezip.version>7.7.10</truezip.version>
-    <ban-junit4-imports.skip>false</ban-junit4-imports.skip>
   </properties>
 
   <dependencyManagement>
@@ -79,7 +79,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>4228.v0a_71308d905b_</version>
+        <version>6931.vea_a_b_c6fd017d</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -94,6 +94,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
+      <version>${commons-compress.version}</version>
     </dependency>
     <dependency>
       <groupId>de.schlichtherle.truezip</groupId>


### PR DESCRIPTION
Builds and releases now consistently use Java 17, resolving the mismatch where the current Jenkins plugin parent required Java 17 while the plugin was still built with Java 11.

The minimum supported Jenkins version is now 2.541.3, which Jenkins lists as one of its [currently recommended core dependencies](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/#currently-recommended-versions). Dependencies and compatibility coverage have also been updated for Freestyle, Pipeline, Matrix, and S3-backed reports. Users running an older Jenkins release must upgrade before installing this plugin version.